### PR TITLE
Fix 100% utilization of two threads while executing this node.

### DIFF
--- a/src/lddc.cpp
+++ b/src/lddc.cpp
@@ -122,7 +122,7 @@ void Lddc::DistributePointCloudData(void) {
   }
   
   while (!lds_->IsRequestExit()) {
-    lds_->semaphore_.Wait();
+    lds_->semaphore_lidar_.Wait();
     for (uint32_t i = 0; i < lds_->lidar_count_; i++) {
       uint32_t lidar_id = i;
       LidarDevice *lidar = &lds_->lidars_[lidar_id];
@@ -142,6 +142,7 @@ void Lddc::DistributeImuData(void) {
   }
   
   while (!lds_->IsRequestExit()) {    
+    lds_->semaphore_imu_.Wait();
     for (uint32_t i = 0; i < lds_->lidar_count_; i++) {
       uint32_t lidar_id = i;
       LidarDevice *lidar = &lds_->lidars_[lidar_id];

--- a/src/lds.cpp
+++ b/src/lds.cpp
@@ -39,7 +39,8 @@ CacheIndex Lds::cache_index_;
 /* Member function --------------------------------------------------------- */
 Lds::Lds(const double publish_freq, const uint8_t data_src)
     : lidar_count_(kMaxSourceLidar),
-      semaphore_(0),
+      semaphore_lidar_(0),
+      semaphore_imu_(0),
       publish_freq_(publish_freq),
       data_src_(data_src),
       request_exit_(false) {
@@ -114,6 +115,9 @@ void Lds::StorageImuData(ImuData* imu_data) {
   LidarDevice *p_lidar = &lidars_[index];
   LidarImuDataQueue* imu_queue = &p_lidar->imu_data;
   imu_queue->Push(imu_data);
+  if (semaphore_imu_.GetCount() <= 0) {
+    semaphore_imu_.Signal();
+  }
 }
 
 void Lds::StorageLvxPointData(PointFrame* frame) {
@@ -178,13 +182,13 @@ void Lds::PushLidarData(PointPacket* lidar_data, const uint8_t index, const uint
   if (!QueueIsFull(queue)) {
     QueuePushAny(queue, (uint8_t *)lidar_data, base_time);
     if (!QueueIsEmpty(queue)) {
-      if (semaphore_.GetCount() <= 0) {
-        semaphore_.Signal();
+      if (semaphore_lidar_.GetCount() <= 0) {
+        semaphore_lidar_.Signal();
       }
     }
   } else {
-    if (semaphore_.GetCount() <= 0) {
-        semaphore_.Signal();
+    if (semaphore_lidar_.GetCount() <= 0) {
+        semaphore_lidar_.Signal();
     }
   }
 }

--- a/src/lds.h
+++ b/src/lds.h
@@ -68,7 +68,8 @@ class Lds {
  public:
   uint8_t lidar_count_;                 /**< Lidar access handle. */
   LidarDevice lidars_[kMaxSourceLidar]; /**< The index is the handle */
-  Semaphore semaphore_;
+  Semaphore semaphore_lidar_;
+  Semaphore semaphore_imu_;
   static CacheIndex cache_index_;
  protected:
   double publish_freq_;

--- a/src/livox_ros_driver2.cpp
+++ b/src/livox_ros_driver2.cpp
@@ -108,8 +108,7 @@ int main(int argc, char **argv) {
 
   livox_node.pointclouddata_poll_thread_ = std::make_shared<std::thread>(&DriverNode::PointCloudDataPollThread, &livox_node);
   livox_node.imudata_poll_thread_ = std::make_shared<std::thread>(&DriverNode::ImuDataPollThread, &livox_node);
-  while (ros::ok()) {}
-
+  ros::waitForShutdown();
   return 0;
 }
 


### PR DESCRIPTION
## Description
I Fixed 100% utilization of two threads while executing this node.

## Changes
- use semaphore in `DistributeImuData()` as `DistributePointCloudData()` one to release CPU in loop process.
- use `ros::waitForShutdown()` instead of `while (ros::ok()) {}`. This can wait for Ctrl+C without occupying CPU.

CPU Usage while executing the node before changes : 2 thread(CPU5, CPU16) are at 100%
![Screenshot from 2023-01-23 18-46-33](https://user-images.githubusercontent.com/63041076/214495328-d7759d9a-b240-4fc2-98ca-8ee94ca2bbc2.png)
After changes :
![Screenshot from 2023-01-25 13-56-00-crop](https://user-images.githubusercontent.com/63041076/214495344-f2cae623-a65b-4fc9-9c04-8bf980627ac5.png)

