### PR TITLE
ROS2: set QoS to best_effort

### DIFF
--- a/src/comm/comm.h
+++ b/src/comm/comm.h
@@ -219,15 +219,42 @@ typedef struct {
   int32_t x;   /**< X translation, unit: mm. */
   int32_t y;   /**< Y translation, unit: mm. */
   int32_t z;   /**< Z translation, unit: mm. */
+  ExtParameterDetailed detail;
+  void UpdateRotationTrans() {
+    detail.trans[0] = x;
+    detail.trans[1] = y;
+    detail.trans[2] = z;
+
+    double cos_roll =
+        cos(static_cast<double>(roll * PI / 180.0));
+    double cos_pitch =
+        cos(static_cast<double>(pitch * PI / 180.0));
+    double cos_yaw =
+        cos(static_cast<double>(yaw * PI / 180.0));
+    double sin_roll =
+        sin(static_cast<double>(roll * PI / 180.0));
+    double sin_pitch =
+        sin(static_cast<double>(pitch * PI / 180.0));
+    double sin_yaw =
+        sin(static_cast<double>(yaw * PI / 180.0));
+
+    detail.rotation[0][0] = cos_pitch * cos_yaw;
+    detail.rotation[0][1] =
+        sin_roll * sin_pitch * cos_yaw - cos_roll * sin_yaw;
+    detail.rotation[0][2] =
+        cos_roll * sin_pitch * cos_yaw + sin_roll * sin_yaw;
+
+    detail.rotation[1][0] = cos_pitch * sin_yaw;
+    detail.rotation[1][1] =
+        sin_roll * sin_pitch * sin_yaw + cos_roll * cos_yaw;
+    detail.rotation[1][2] =
+        cos_roll * sin_pitch * sin_yaw - sin_roll * cos_yaw;
+
+    detail.rotation[2][0] = -sin_pitch;
+    detail.rotation[2][1] = sin_roll * cos_pitch;
+    detail.rotation[2][2] = cos_roll * cos_pitch;
+  }
 } ExtParameter;
-
-typedef float TranslationVector[3]; /**< x, y, z translation, unit: mm. */
-typedef float RotationMatrix[3][3];
-
-typedef struct {
-  TranslationVector trans;
-  RotationMatrix rotation;
-} ExtParameterDetailed;
 
 typedef struct {
   LidarProtoType lidar_type;

--- a/src/comm/lidar_imu_data_queue.cpp
+++ b/src/comm/lidar_imu_data_queue.cpp
@@ -26,19 +26,38 @@
 
 namespace livox_ros {
 
-void LidarImuDataQueue::Push(ImuData* imu_data) {
+void LidarImuDataQueue::Push(ImuData *imu_data,
+                             const ExtParameterDetailed &detail) {
   ImuData data;
   data.lidar_type = imu_data->lidar_type;
   data.handle = imu_data->handle;
   data.time_stamp = imu_data->time_stamp;
 
-  data.gyro_x = imu_data->gyro_x;
-  data.gyro_y = imu_data->gyro_y;
-  data.gyro_z = imu_data->gyro_z;
+  data.acc_x = imu_data->acc_x * detail.rotation[0][0] +
+               imu_data->acc_y * detail.rotation[0][1] +
+               imu_data->acc_z * detail.rotation[0][2] +
+               detail.trans[0] * 1000.0;
+  data.acc_y = imu_data->acc_x * detail.rotation[1][0] +
+               imu_data->acc_y * detail.rotation[1][1] +
+               imu_data->acc_z * detail.rotation[1][2] +
+               detail.trans[1] * 1000.0;
+  data.acc_z = imu_data->acc_x * detail.rotation[2][0] +
+               imu_data->acc_y * detail.rotation[2][1] +
+               imu_data->acc_z * detail.rotation[2][2] +
+               detail.trans[2] * 1000.0;
 
-  data.acc_x = imu_data->acc_x;
-  data.acc_y = imu_data->acc_y;
-  data.acc_z = imu_data->acc_z;
+  data.gyro_x = imu_data->gyro_x * detail.rotation[0][0] +
+                imu_data->gyro_y * detail.rotation[0][1] +
+                imu_data->gyro_z * detail.rotation[0][2] +
+                detail.trans[0] * 1000.0;
+  data.gyro_y = imu_data->gyro_x * detail.rotation[1][0] +
+                imu_data->gyro_y * detail.rotation[1][1] +
+                imu_data->gyro_z * detail.rotation[1][2] +
+                detail.trans[1] * 1000.0;
+  data.gyro_z = imu_data->gyro_x * detail.rotation[2][0] +
+                imu_data->gyro_y * detail.rotation[2][1] +
+                imu_data->gyro_z * detail.rotation[2][2] +
+                detail.trans[2] * 1000.0;
 
   std::lock_guard<std::mutex> lock(mutex_);
   imu_data_queue_.push_back(std::move(data));

--- a/src/comm/lidar_imu_data_queue.h
+++ b/src/comm/lidar_imu_data_queue.h
@@ -59,12 +59,20 @@ typedef struct {
   float acc_z;         /**< Accelerometer Z axis, Unit:g */
 } ImuData;
 
+typedef float TranslationVector[3]; /**< x, y, z translation, unit: mm. */
+typedef float RotationMatrix[3][3];
+
+typedef struct {
+  TranslationVector trans;
+  RotationMatrix rotation;
+} ExtParameterDetailed;
+
 class LidarImuDataQueue {
  public:
-  void Push(ImuData* imu_data);
-  bool Pop(ImuData& imu_data);
-  bool Empty();
-  void Clear();
+   void Push(ImuData *imu_data, const ExtParameterDetailed& detail);
+   bool Pop(ImuData &imu_data);
+   bool Empty();
+   void Clear();
 
  private:
   std::mutex mutex_;

--- a/src/lddc.cpp
+++ b/src/lddc.cpp
@@ -521,27 +521,30 @@ void Lddc::PublishImuData(LidarImuDataQueue& imu_data_queue, const uint8_t index
 #ifdef BUILDING_ROS2
 std::shared_ptr<rclcpp::PublisherBase> Lddc::CreatePublisher(uint8_t msg_type,
     std::string &topic_name, uint32_t queue_size) {
+    rclcpp::QoS policy(queue_size);
+    policy.best_effort();
+    policy.durability_volatile();
     if (kPointCloud2Msg == msg_type) {
       DRIVER_INFO(*cur_node_,
           "%s publish use PointCloud2 format", topic_name.c_str());
-      return cur_node_->create_publisher<PointCloud2>(topic_name, queue_size);
+      return cur_node_->create_publisher<PointCloud2>(topic_name, policy);
     } else if (kLivoxCustomMsg == msg_type) {
       DRIVER_INFO(*cur_node_,
           "%s publish use livox custom format", topic_name.c_str());
-      return cur_node_->create_publisher<CustomMsg>(topic_name, queue_size);
+      return cur_node_->create_publisher<CustomMsg>(topic_name, policy);
     }
 #if 0
     else if (kPclPxyziMsg == msg_type)  {
       DRIVER_INFO(*cur_node_,
           "%s publish use pcl PointXYZI format", topic_name.c_str());
-      return cur_node_->create_publisher<PointCloud>(topic_name, queue_size);
+      return cur_node_->create_publisher<PointCloud>(topic_name, policy);
     }
 #endif
     else if (kLivoxImuMsg == msg_type)  {
       DRIVER_INFO(*cur_node_,
           "%s publish use imu format", topic_name.c_str());
       return cur_node_->create_publisher<ImuMsg>(topic_name,
-          queue_size);
+          policy);
     } else {
       PublisherPtr null_publisher(nullptr);
       return null_publisher;

--- a/src/lds.cpp
+++ b/src/lds.cpp
@@ -114,7 +114,7 @@ void Lds::StorageImuData(ImuData* imu_data) {
 
   LidarDevice *p_lidar = &lidars_[index];
   LidarImuDataQueue* imu_queue = &p_lidar->imu_data;
-  imu_queue->Push(imu_data);
+  imu_queue->Push(imu_data, p_lidar->livox_config.extrinsic_param.detail);
   if (!imu_queue->Empty()) {
     if (imu_semaphore_.GetCount() <= 0) {
       imu_semaphore_.Signal();

--- a/src/parse_cfg_file/parse_livox_lidar_cfg.cpp
+++ b/src/parse_cfg_file/parse_livox_lidar_cfg.cpp
@@ -149,6 +149,7 @@ bool LivoxLidarConfigParser::ParseExtrinsics(const rapidjson::Value &value,
   } else {
     param.z = static_cast<int32_t>(value["z"].GetInt());
   }
+  param.UpdateRotationTrans();
 
   return true;
 }


### PR DESCRIPTION
ros2 使用了 DDS 通信机制，不同于 ros 单一的通信机制，它可以配置多种参数以适配不同的应用场景

这个 QoS 配置是根据 [SEnsorDataQos](https://docs.ros2.org/latest/api/rclcpp/classrclcpp_1_1SensorDataQoS.html) 配置修改的

系统默认通信方式的在大多数性能足够的电脑上没有问题，可以跑到指定的频率，但在一些资源受限的 arm 平台上效果非常差，修改 QoS 配置后可以跑到指定频率

在 khadas-vim4、香橙派5 上测试过