### PR TITLE
Enabled config a nick name for multi lidar topics

### DIFF
--- a/config/HAP_config _multi org.json
+++ b/config/HAP_config _multi org.json
@@ -28,7 +28,7 @@
   "lidar_configs" : [
     {
       "ip" : "192.168.1.101",
-      "nickName" : "R",
+      "name" : "R",
       "pcl_data_type" : 1,
       "pattern_mode" : 0,
       "frame_id" : "rslidar",
@@ -44,7 +44,7 @@
     ,
     {
       "ip" : "192.168.1.102",
-      "nickName" : "L",
+      "name" : "L",
       "pcl_data_type" : 1,
       "pattern_mode" : 0,
       "frame_id" : "rslidar",

--- a/config/HAP_config _multi org.json
+++ b/config/HAP_config _multi org.json
@@ -13,7 +13,7 @@
     "host_net_info" : {
       "cmd_data_ip" : "192.168.1.2",
       "cmd_data_port": 56000,
-      "push_msg_ip": "192.168.1.2",
+      "push_msg_ip": "",
       "push_msg_port": 0,
       "point_data_ip": "192.168.1.2",
       "point_data_port": 57000,
@@ -23,27 +23,7 @@
       "log_data_port": 59000
     }
   },
-  "HAP": {
-    "lidar_net_info" : {
-      "cmd_data_port": 56000,
-      "push_msg_port": 0,
-      "point_data_port": 57000,
-      "imu_data_port": 58000,
-      "log_data_port": 59000
-    },
-    "host_net_info" : {
-      "cmd_data_ip" : "192.168.1.2",
-      "cmd_data_port": 56002,
-      "push_msg_ip": "192.168.1.2",
-      "push_msg_port": 2,
-      "point_data_ip": "192.168.1.2",
-      "point_data_port": 57002,
-      "imu_data_ip" : "192.168.1.2",
-      "imu_data_port": 58002,
-      "log_data_ip" : "",
-      "log_data_port": 59002
-    }
-  },
+  
   
   "lidar_configs" : [
     {
@@ -55,7 +35,7 @@
       "extrinsic_parameter" : {
         "roll": 0.0,
         "pitch": 0.0,
-        "yaw": -120.0,
+        "yaw": 0.0,
         "x": 0,
         "y": 0,
         "z": 0
@@ -67,23 +47,7 @@
       "nickName" : "L",
       "pcl_data_type" : 1,
       "pattern_mode" : 0,
-      "frame_id" : "lslidar",
-      "extrinsic_parameter" : {
-        "roll": 0.0,
-        "pitch": 0.0,
-        "yaw": 120.0,
-        "x": 0,
-        "y": 0,
-        "z": 0
-      }
-    }
-    ,
-    {
-      "ip" : "192.168.1.100",
-      "nickName" : "F",
-      "pcl_data_type" : 1,
-      "pattern_mode" : 0,
-      "frame_id" : "fslidar",
+      "frame_id" : "rslidar",
       "extrinsic_parameter" : {
         "roll": 0.0,
         "pitch": 0.0,

--- a/config/HAP_config _multi.json
+++ b/config/HAP_config _multi.json
@@ -48,10 +48,9 @@
   "lidar_configs" : [
     {
       "ip" : "192.168.1.101",
-      "nickName" : "R",
+      "name" : "Right",
       "pcl_data_type" : 1,
       "pattern_mode" : 0,
-      "frame_id" : "rslidar",
       "extrinsic_parameter" : {
         "roll": 0.0,
         "pitch": 0.0,
@@ -64,10 +63,9 @@
     ,
     {
       "ip" : "192.168.1.102",
-      "nickName" : "L",
+      "name" : "Left",
       "pcl_data_type" : 1,
       "pattern_mode" : 0,
-      "frame_id" : "lslidar",
       "extrinsic_parameter" : {
         "roll": 0.0,
         "pitch": 0.0,
@@ -80,10 +78,9 @@
     ,
     {
       "ip" : "192.168.1.100",
-      "nickName" : "F",
+      "name" : "Front",
       "pcl_data_type" : 1,
       "pattern_mode" : 0,
-      "frame_id" : "fslidar",
       "extrinsic_parameter" : {
         "roll": 0.0,
         "pitch": 0.0,

--- a/config/HAP_config _multi.json
+++ b/config/HAP_config _multi.json
@@ -1,0 +1,59 @@
+{
+  "lidar_summary_info" : {
+    "lidar_type": 8
+  },
+  "HAP": {
+    "lidar_net_info" : {
+      "cmd_data_port": 56000,
+      "push_msg_port": 0,
+      "point_data_port": 57000,
+      "imu_data_port": 58000,
+      "log_data_port": 59000
+    },
+    "host_net_info" : {
+      "cmd_data_ip" : "192.168.1.2",
+      "cmd_data_port": 56000,
+      "push_msg_ip": "",
+      "push_msg_port": 0,
+      "point_data_ip": "192.168.1.2",
+      "point_data_port": 57000,
+      "imu_data_ip" : "192.168.1.2",
+      "imu_data_port": 58000,
+      "log_data_ip" : "",
+      "log_data_port": 59000
+    }
+  },
+  
+  "lidar_configs" : [
+    {
+      "ip" : "192.168.1.101",
+      "nickName" : "lidar1",
+      "pcl_data_type" : 1,
+      "pattern_mode" : 0,
+      "extrinsic_parameter" : {
+        "roll": 0.0,
+        "pitch": 0.0,
+        "yaw": 0.0,
+        "x": 0,
+        "y": 0,
+        "z": 0
+      }
+    }
+    ,
+    {
+      "ip" : "192.168.1.102",
+      "nickName" : "lidar2",
+      "pcl_data_type" : 1,
+      "pattern_mode" : 0,
+      "extrinsic_parameter" : {
+        "roll": 0.0,
+        "pitch": 0.0,
+        "yaw": 0.0,
+        "x": 0,
+        "y": 0,
+        "z": 0
+      }
+    }
+  ]
+}
+

--- a/config/HAP_config.json
+++ b/config/HAP_config.json
@@ -11,13 +11,13 @@
       "log_data_port": 59000
     },
     "host_net_info" : {
-      "cmd_data_ip" : "192.168.1.5",
+      "cmd_data_ip" : "192.168.1.2",
       "cmd_data_port": 56000,
       "push_msg_ip": "",
       "push_msg_port": 0,
-      "point_data_ip": "192.168.1.5",
+      "point_data_ip": "192.168.1.2",
       "point_data_port": 57000,
-      "imu_data_ip" : "192.168.1.5",
+      "imu_data_ip" : "192.168.1.2",
       "imu_data_port": 58000,
       "log_data_ip" : "",
       "log_data_port": 59000

--- a/launch_ROS1/rviz_HAP_multi.launch
+++ b/launch_ROS1/rviz_HAP_multi.launch
@@ -1,0 +1,47 @@
+<launch>
+
+	<!--user configure parameters for ros start-->
+	<arg name="lvx_file_path" default="livox_test.lvx"/>
+	<arg name="bd_list" default="100000000000000"/>
+	<arg name="xfer_format" default="0"/>
+	<arg name="multi_topic" default="1"/>
+	<arg name="data_src" default="0"/>
+	<arg name="publish_freq" default="10.0"/>
+	<arg name="output_type" default="0"/>
+	<arg name="rviz_enable" default="true"/>
+	<arg name="rosbag_enable" default="false"/>
+	<arg name="cmdline_arg" default="$(arg bd_list)"/>
+	<arg name="msg_frame_id" default="livox_frame"/>
+	<arg name="lidar_bag" default="true"/>
+	<arg name="imu_bag" default="true"/>
+	<!--user configure parameters for ros end--> 
+
+	<param name="xfer_format" value="$(arg xfer_format)"/>
+	<param name="multi_topic" value="$(arg multi_topic)"/>
+	<param name="data_src" value="$(arg data_src)"/>
+	<param name="publish_freq" type="double" value="$(arg publish_freq)"/>
+	<param name="output_data_type" value="$(arg output_type)"/>
+	<param name="cmdline_str" type="string" value="$(arg bd_list)"/>
+	<param name="cmdline_file_path" type="string" value="$(arg lvx_file_path)"/>
+	<param name="user_config_path" type="string" value="$(find livox_ros_driver2)/config/HAP_config _multi.json"/>
+	<param name="frame_id" type="string" value="$(arg msg_frame_id)"/>
+	<param name="enable_lidar_bag" type="bool" value="$(arg lidar_bag)"/>
+	<param name="enable_imu_bag" type="bool" value="$(arg imu_bag)"/>
+
+	<node name="livox_lidar_publisher2" pkg="livox_ros_driver2"
+	      type="livox_ros_driver2_node" required="true"
+	      output="screen" args="$(arg cmdline_arg)"/>
+
+	<group if="$(arg rviz_enable)">
+		<node name="livox_rviz" pkg="rviz" type="rviz" respawn="true"
+				args="-d $(find livox_ros_driver2)/config/display_point_cloud_ROS1.rviz"/>
+    </group>
+	<group if="$(arg rosbag_enable)">
+    	<node pkg="rosbag" type="record" name="record" output="screen"
+          		args="-a"/>
+    </group>
+
+	<!-- <node pkg="rosparam" type="rosparam" name="param_dump" args="dump /livox_lidar_publisher2"/> -->
+
+
+</launch>

--- a/launch_ROS1/rviz_HAP_multi.launch
+++ b/launch_ROS1/rviz_HAP_multi.launch
@@ -8,7 +8,7 @@
 	<arg name="data_src" default="0"/>
 	<arg name="publish_freq" default="10.0"/>
 	<arg name="output_type" default="0"/>
-	<arg name="rviz_enable" default="true"/>
+	<arg name="rviz_enable" default="false"/>
 	<arg name="rosbag_enable" default="false"/>
 	<arg name="cmdline_arg" default="$(arg bd_list)"/>
 	<arg name="msg_frame_id" default="livox_frame"/>

--- a/src/comm/comm.h
+++ b/src/comm/comm.h
@@ -265,6 +265,7 @@ typedef struct {
   int32_t blind_spot_set;
   int8_t dual_emit_en;
   ExtParameter extrinsic_param;
+  std::string nickName;
   volatile uint32_t set_bits;
   volatile uint32_t get_bits;
 } UserLivoxLidarConfig;

--- a/src/comm/comm.h
+++ b/src/comm/comm.h
@@ -265,7 +265,7 @@ typedef struct {
   int32_t blind_spot_set;
   int8_t dual_emit_en;
   ExtParameter extrinsic_param;
-  std::string nickName;
+  std::string ldName;
   volatile uint32_t set_bits;
   volatile uint32_t get_bits;
 } UserLivoxLidarConfig;

--- a/src/lddc.cpp
+++ b/src/lddc.cpp
@@ -572,12 +572,12 @@ PublisherPtr Lddc::GetCurrentPublisher(uint8_t index) {
     memset(name_str, 0, sizeof(name_str));
     if (use_multi_topic_) {
       std::string nickName = lds_->lidars_[index].livox_config.nickName; 
-      snprintf(name_str, sizeof(name_str), "livox/lidar_%s",
+      snprintf(name_str, sizeof(name_str), "livox/lidar_%s/points",
                ReplacePeriodByUnderline(nickName).c_str()); 
       DRIVER_INFO(*cur_node_, "Support multi topics.");
     } else {
       DRIVER_INFO(*cur_node_, "Support only one topic.");
-      snprintf(name_str, sizeof(name_str), "livox/lidar");
+      snprintf(name_str, sizeof(name_str), "livox/lidar/points");
     }
 
     *pub = new ros::Publisher;
@@ -622,12 +622,12 @@ PublisherPtr Lddc::GetCurrentImuPublisher(uint8_t handle) {
     memset(name_str, 0, sizeof(name_str));
     if (use_multi_topic_) {
       DRIVER_INFO(*cur_node_, "Support multi topics.");
-      std::string ip_string = IpNumToString(lds_->lidars_[handle].handle);
-      snprintf(name_str, sizeof(name_str), "livox/imu_%s",
-               ReplacePeriodByUnderline(ip_string).c_str());
+      std::string nickName = lds_->lidars_[handle].livox_config.nickName; 
+      snprintf(name_str, sizeof(name_str), "livox/lidar_%s/imu",
+               ReplacePeriodByUnderline(nickName).c_str());
     } else {
       DRIVER_INFO(*cur_node_, "Support only one topic.");
-      snprintf(name_str, sizeof(name_str), "livox/imu");
+      snprintf(name_str, sizeof(name_str), "livox/lidar/imu");
     }
 
     *pub = new ros::Publisher;

--- a/src/lddc.cpp
+++ b/src/lddc.cpp
@@ -571,9 +571,9 @@ PublisherPtr Lddc::GetCurrentPublisher(uint8_t index) {
     char name_str[48];
     memset(name_str, 0, sizeof(name_str));
     if (use_multi_topic_) {
-      std::string ip_string = IpNumToString(lds_->lidars_[index].handle);
+      std::string nickName = lds_->lidars_[index].livox_config.nickName; 
       snprintf(name_str, sizeof(name_str), "livox/lidar_%s",
-               ReplacePeriodByUnderline(ip_string).c_str());
+               ReplacePeriodByUnderline(nickName).c_str()); 
       DRIVER_INFO(*cur_node_, "Support multi topics.");
     } else {
       DRIVER_INFO(*cur_node_, "Support only one topic.");

--- a/src/lddc.cpp
+++ b/src/lddc.cpp
@@ -571,9 +571,9 @@ PublisherPtr Lddc::GetCurrentPublisher(uint8_t index) {
     char name_str[48];
     memset(name_str, 0, sizeof(name_str));
     if (use_multi_topic_) {
-      std::string nickName = lds_->lidars_[index].livox_config.nickName; 
-      snprintf(name_str, sizeof(name_str), "livox/lidar_%s/points",
-               ReplacePeriodByUnderline(nickName).c_str()); 
+      std::string ldName = lds_->lidars_[index].livox_config.ldName; 
+      snprintf(name_str, sizeof(name_str), "livox/lidar/%s/points",
+               ReplacePeriodByUnderline(ldName).c_str()); 
       DRIVER_INFO(*cur_node_, "Support multi topics.");
     } else {
       DRIVER_INFO(*cur_node_, "Support only one topic.");
@@ -622,9 +622,9 @@ PublisherPtr Lddc::GetCurrentImuPublisher(uint8_t handle) {
     memset(name_str, 0, sizeof(name_str));
     if (use_multi_topic_) {
       DRIVER_INFO(*cur_node_, "Support multi topics.");
-      std::string nickName = lds_->lidars_[handle].livox_config.nickName; 
-      snprintf(name_str, sizeof(name_str), "livox/lidar_%s/imu",
-               ReplacePeriodByUnderline(nickName).c_str());
+      std::string ldName = lds_->lidars_[handle].livox_config.ldName; 
+      snprintf(name_str, sizeof(name_str), "livox/lidar/%s/imu",
+               ReplacePeriodByUnderline(ldName).c_str());
     } else {
       DRIVER_INFO(*cur_node_, "Support only one topic.");
       snprintf(name_str, sizeof(name_str), "livox/lidar/imu");

--- a/src/lds_lidar.cpp
+++ b/src/lds_lidar.cpp
@@ -133,7 +133,7 @@ bool LdsLidar::InitLivoxLidar() {
 
   // parse user config
   LivoxLidarConfigParser parser(path_);
-  // std::vector<UserLivoxLidarConfig> user_configs;
+
   if (!parser.Parse(user_configs)) {
     std::cout << "failed to parse user-defined config" << std::endl;
   }
@@ -202,11 +202,8 @@ int LdsLidar::DeInitLdsLidar(void) {
   }
 
   if (lidar_summary_info_.lidar_type & kLivoxLidarType) {
-    // kLivoxLidarWakeUp 
-    // kLivoxLidarSleep 
-    // SetLivoxLidarWorkMode(uint32_t handle, LivoxLidarWorkMode work_mode, LivoxLidarAsyncControlCallback cb, void* client_data);
+    // setting the lidars to idel state when closing
     LivoxLidarWorkMode mode = kLivoxLidarWakeUp;
-    // LivoxLidarCallback::WorkModeChangedCallback
     for (auto& config : user_configs) {
       SetLivoxLidarWorkMode(config.handle, mode, nullptr , nullptr);
     }

--- a/src/lds_lidar.cpp
+++ b/src/lds_lidar.cpp
@@ -133,7 +133,7 @@ bool LdsLidar::InitLivoxLidar() {
 
   // parse user config
   LivoxLidarConfigParser parser(path_);
-  std::vector<UserLivoxLidarConfig> user_configs;
+  // std::vector<UserLivoxLidarConfig> user_configs;
   if (!parser.Parse(user_configs)) {
     std::cout << "failed to parse user-defined config" << std::endl;
   }
@@ -202,6 +202,14 @@ int LdsLidar::DeInitLdsLidar(void) {
   }
 
   if (lidar_summary_info_.lidar_type & kLivoxLidarType) {
+    // kLivoxLidarWakeUp 
+    // kLivoxLidarSleep 
+    // SetLivoxLidarWorkMode(uint32_t handle, LivoxLidarWorkMode work_mode, LivoxLidarAsyncControlCallback cb, void* client_data);
+    LivoxLidarWorkMode mode = kLivoxLidarWakeUp;
+    // LivoxLidarCallback::WorkModeChangedCallback
+    for (auto& config : user_configs) {
+      SetLivoxLidarWorkMode(config.handle, mode, nullptr , nullptr);
+    }
     LivoxLidarSdkUninit();
     printf("Livox Lidar SDK Deinit completely!\n");
   }

--- a/src/lds_lidar.h
+++ b/src/lds_lidar.h
@@ -54,6 +54,7 @@ class LdsLidar final : public Lds {
 
   int DeInitLdsLidar(void);
  private:
+  std::vector<UserLivoxLidarConfig> user_configs;
   LdsLidar(double publish_freq);
   LdsLidar(const LdsLidar &) = delete;
   ~LdsLidar();

--- a/src/parse_cfg_file/parse_livox_lidar_cfg.cpp
+++ b/src/parse_cfg_file/parse_livox_lidar_cfg.cpp
@@ -72,10 +72,10 @@ bool LivoxLidarConfigParser::ParseUserConfigs(const rapidjson::Document &doc,
 
     // parse user configs
     user_config.handle = IpStringToNum(std::string(config["ip"].GetString()));
-    if(!config.HasMember("nickName")) {
-      user_config.nickName = config["ip"].GetString();
+    if(!config.HasMember("name")) {
+      user_config.ldName = config["ip"].GetString();
     } else {
-      user_config.nickName = config["nickName"].GetString();
+      user_config.ldName = config["name"].GetString();
     }
     if (!config.HasMember("pcl_data_type")) {
       user_config.pcl_data_type = -1;

--- a/src/parse_cfg_file/parse_livox_lidar_cfg.cpp
+++ b/src/parse_cfg_file/parse_livox_lidar_cfg.cpp
@@ -72,6 +72,11 @@ bool LivoxLidarConfigParser::ParseUserConfigs(const rapidjson::Document &doc,
 
     // parse user configs
     user_config.handle = IpStringToNum(std::string(config["ip"].GetString()));
+    if(!config.HasMember("nickName")) {
+      user_config.nickName = config["ip"].GetString();
+    } else {
+      user_config.nickName = config["nickName"].GetString();
+    }
     if (!config.HasMember("pcl_data_type")) {
       user_config.pcl_data_type = -1;
     } else {


### PR DESCRIPTION
When working with muliti lidar I noticed the name for each point cloud topic is named by the ip address. In my version, only if the user has added "nickName" as in "config/HAP_config _multi.json", the driver will attach this name to the topicname instead of the ip add.