### PR TITLE
Fix clang error when compling on MacOS15.1.1

### DIFF
--- a/3rdparty/rapidjson/document.h
+++ b/3rdparty/rapidjson/document.h
@@ -31,13 +31,18 @@
 
 RAPIDJSON_DIAG_PUSH
 #ifdef __clang__
+#if __has_warning("-Wpadded")
 RAPIDJSON_DIAG_OFF(padded)
-RAPIDJSON_DIAG_OFF(switch - enum)
-RAPIDJSON_DIAG_OFF(c++ 98 - compat)
+#endif
+#if __has_warning("-Wswitch-enum")
+RAPIDJSON_DIAG_OFF(switch-enum)
+#endif
+#if __has_warning("-Wc++98-compat")
+RAPIDJSON_DIAG_OFF(c++98-compat)
+#endif
 #elif defined(_MSC_VER)
-RAPIDJSON_DIAG_OFF(4127)  // conditional expression is constant
-RAPIDJSON_DIAG_OFF(
-    4244)  // conversion from kXxxFlags to 'uint16_t', possible loss of data
+RAPIDJSON_DIAG_OFF(4127) // conditional expression is constant
+RAPIDJSON_DIAG_OFF(4244) // conversion from kXxxFlags to 'uint16_t', possible loss of data
 #endif
 
 #ifdef __GNUC__

--- a/3rdparty/rapidjson/encodedstream.h
+++ b/3rdparty/rapidjson/encodedstream.h
@@ -29,7 +29,9 @@ RAPIDJSON_DIAG_OFF(effc++)
 
 #ifdef __clang__
 RAPIDJSON_DIAG_PUSH
+#if __has_warning("-Wpadded")
 RAPIDJSON_DIAG_OFF(padded)
+#endif
 #endif
 
 RAPIDJSON_NAMESPACE_BEGIN

--- a/3rdparty/rapidjson/error/en.h
+++ b/3rdparty/rapidjson/error/en.h
@@ -23,8 +23,12 @@
 
 #ifdef __clang__
 RAPIDJSON_DIAG_PUSH
-RAPIDJSON_DIAG_OFF(switch - enum)
-RAPIDJSON_DIAG_OFF(covered - switch - default)
+#if __has_warning("-Wswitch-enum")
+RAPIDJSON_DIAG_OFF(switch-enum)
+#endif
+#if __has_warning("-Wcovered-switch-default")
+RAPIDJSON_DIAG_OFF(covered-switch-default)
+#endif
 #endif
 
 RAPIDJSON_NAMESPACE_BEGIN

--- a/3rdparty/rapidjson/error/error.h
+++ b/3rdparty/rapidjson/error/error.h
@@ -23,7 +23,9 @@
 
 #ifdef __clang__
 RAPIDJSON_DIAG_PUSH
+#if __has_warning("-Wpadded")
 RAPIDJSON_DIAG_OFF(padded)
+#endif
 #endif
 
 /*! \file error.h */

--- a/3rdparty/rapidjson/filereadstream.h
+++ b/3rdparty/rapidjson/filereadstream.h
@@ -24,9 +24,15 @@
 
 #ifdef __clang__
 RAPIDJSON_DIAG_PUSH
+#if __has_warning("-Wpadded")
 RAPIDJSON_DIAG_OFF(padded)
-RAPIDJSON_DIAG_OFF(unreachable - code)
-RAPIDJSON_DIAG_OFF(missing - noreturn)
+#endif
+#if __has_warning("-Wunreachable-code")
+RAPIDJSON_DIAG_OFF(unreachable-code)
+#endif
+#if __has_warning("-Wmissing-noreturn")
+RAPIDJSON_DIAG_OFF(missing-noreturn)
+#endif
 #endif
 
 RAPIDJSON_NAMESPACE_BEGIN

--- a/3rdparty/rapidjson/filewritestream.h
+++ b/3rdparty/rapidjson/filewritestream.h
@@ -24,7 +24,9 @@
 
 #ifdef __clang__
 RAPIDJSON_DIAG_PUSH
-RAPIDJSON_DIAG_OFF(unreachable - code)
+#if __has_warning("-Wunreachable-code")
+RAPIDJSON_DIAG_OFF(unreachable-code)
+#endif
 #endif
 
 RAPIDJSON_NAMESPACE_BEGIN

--- a/3rdparty/rapidjson/internal/diyfp.h
+++ b/3rdparty/rapidjson/internal/diyfp.h
@@ -42,7 +42,9 @@ RAPIDJSON_DIAG_OFF(effc++)
 
 #ifdef __clang__
 RAPIDJSON_DIAG_PUSH
+#if __has_warning("-Wpadded")
 RAPIDJSON_DIAG_OFF(padded)
+#endif
 #endif
 
 struct DiyFp {

--- a/3rdparty/rapidjson/internal/dtoa.h
+++ b/3rdparty/rapidjson/internal/dtoa.h
@@ -33,7 +33,7 @@ namespace internal {
 #ifdef __GNUC__
 RAPIDJSON_DIAG_PUSH
 RAPIDJSON_DIAG_OFF(effc++)
-RAPIDJSON_DIAG_OFF(array - bounds)  // some gcc versions generate wrong warnings
+RAPIDJSON_DIAG_OFF(array-bounds)  // some gcc versions generate wrong warnings
 // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=59124
 #endif
 

--- a/3rdparty/rapidjson/internal/regex.h
+++ b/3rdparty/rapidjson/internal/regex.h
@@ -25,8 +25,12 @@
 
 #ifdef __clang__
 RAPIDJSON_DIAG_PUSH
+#if __has_warning("-Wpadded")
 RAPIDJSON_DIAG_OFF(padded)
-RAPIDJSON_DIAG_OFF(switch - enum)
+#endif
+#if __has_warning("-Wswitch-enum")
+RAPIDJSON_DIAG_OFF(switch-enum)
+#endif
 #elif defined(_MSC_VER)
 RAPIDJSON_DIAG_PUSH
 RAPIDJSON_DIAG_OFF(4512)  // assignment operator could not be generated

--- a/3rdparty/rapidjson/internal/stack.h
+++ b/3rdparty/rapidjson/internal/stack.h
@@ -25,7 +25,9 @@
 
 #if defined(__clang__)
 RAPIDJSON_DIAG_PUSH
-RAPIDJSON_DIAG_OFF(c++ 98 - compat)
+#if __has_warning("-Wc++98-compat")
+RAPIDJSON_DIAG_OFF(c++98-compat)
+#endif
 #endif
 
 RAPIDJSON_NAMESPACE_BEGIN

--- a/3rdparty/rapidjson/internal/swap.h
+++ b/3rdparty/rapidjson/internal/swap.h
@@ -23,7 +23,9 @@
 
 #if defined(__clang__)
 RAPIDJSON_DIAG_PUSH
-RAPIDJSON_DIAG_OFF(c++ 98 - compat)
+#if __has_warning("-Wc++98-compat")
+RAPIDJSON_DIAG_OFF(c++98-compat)
+#endif
 #endif
 
 RAPIDJSON_NAMESPACE_BEGIN

--- a/3rdparty/rapidjson/istreamwrapper.h
+++ b/3rdparty/rapidjson/istreamwrapper.h
@@ -25,7 +25,9 @@
 
 #ifdef __clang__
 RAPIDJSON_DIAG_PUSH
+#if __has_warning("-Wpadded")
 RAPIDJSON_DIAG_OFF(padded)
+#endif
 #elif defined(_MSC_VER)
 RAPIDJSON_DIAG_PUSH
 RAPIDJSON_DIAG_OFF(4351)  // new behavior: elements of array 'array' will be

--- a/3rdparty/rapidjson/memorystream.h
+++ b/3rdparty/rapidjson/memorystream.h
@@ -23,8 +23,12 @@
 
 #ifdef __clang__
 RAPIDJSON_DIAG_PUSH
-RAPIDJSON_DIAG_OFF(unreachable - code)
-RAPIDJSON_DIAG_OFF(missing - noreturn)
+#if __has_warning("-Wunreachable-code")
+RAPIDJSON_DIAG_OFF(unreachable-code)
+#endif
+#if __has_warning("-Wmissing-noreturn")
+RAPIDJSON_DIAG_OFF(missing-noreturn)
+#endif
 #endif
 
 RAPIDJSON_NAMESPACE_BEGIN

--- a/3rdparty/rapidjson/ostreamwrapper.h
+++ b/3rdparty/rapidjson/ostreamwrapper.h
@@ -24,7 +24,9 @@
 
 #ifdef __clang__
 RAPIDJSON_DIAG_PUSH
+#if __has_warning("-Wpadded")
 RAPIDJSON_DIAG_OFF(padded)
+#endif
 #endif
 
 RAPIDJSON_NAMESPACE_BEGIN

--- a/3rdparty/rapidjson/pointer.h
+++ b/3rdparty/rapidjson/pointer.h
@@ -24,7 +24,9 @@
 
 #ifdef __clang__
 RAPIDJSON_DIAG_PUSH
-RAPIDJSON_DIAG_OFF(switch - enum)
+#if __has_warning("-Wswitch-enum")
+RAPIDJSON_DIAG_OFF(switch-enum)
+#endif
 #elif defined(_MSC_VER)
 RAPIDJSON_DIAG_PUSH
 RAPIDJSON_DIAG_OFF(4512)  // assignment operator could not be generated

--- a/3rdparty/rapidjson/prettywriter.h
+++ b/3rdparty/rapidjson/prettywriter.h
@@ -28,7 +28,9 @@ RAPIDJSON_DIAG_OFF(effc++)
 
 #if defined(__clang__)
 RAPIDJSON_DIAG_PUSH
-RAPIDJSON_DIAG_OFF(c++ 98 - compat)
+#if __has_warning("-Wc++98-compat")
+RAPIDJSON_DIAG_OFF(c++98-compat)
+#endif
 #endif
 
 RAPIDJSON_NAMESPACE_BEGIN

--- a/3rdparty/rapidjson/reader.h
+++ b/3rdparty/rapidjson/reader.h
@@ -44,9 +44,15 @@
 
 #ifdef __clang__
 RAPIDJSON_DIAG_PUSH
-RAPIDJSON_DIAG_OFF(old - style - cast)
+#if __has_warning("-Wold-style-cast")
+RAPIDJSON_DIAG_OFF(old-style-cast)
+#endif
+#if __has_warning("-Wpadded")
 RAPIDJSON_DIAG_OFF(padded)
-RAPIDJSON_DIAG_OFF(switch - enum)
+#endif
+#if __has_warning("-Wswitch-enum")
+RAPIDJSON_DIAG_OFF(switch-enum)
+#endif
 #elif defined(_MSC_VER)
 RAPIDJSON_DIAG_PUSH
 RAPIDJSON_DIAG_OFF(4127)  // conditional expression is constant

--- a/3rdparty/rapidjson/schema.h
+++ b/3rdparty/rapidjson/schema.h
@@ -65,10 +65,18 @@ RAPIDJSON_DIAG_OFF(effc++)
 #endif
 
 #ifdef __clang__
-RAPIDJSON_DIAG_OFF(weak - vtables)
-RAPIDJSON_DIAG_OFF(exit - time - destructors)
-RAPIDJSON_DIAG_OFF(c++ 98 - compat - pedantic)
-RAPIDJSON_DIAG_OFF(variadic - macros)
+#if __has_warning("-Wweak-vtables")
+RAPIDJSON_DIAG_OFF(weak-vtables)
+#endif
+#if __has_warning("-Wexit-time-destructors")
+RAPIDJSON_DIAG_OFF(exit-time-destructors)
+#endif
+#if __has_warning("-Wc++98-compat-pedantic")
+RAPIDJSON_DIAG_OFF(c++98-compat-pedantic)
+#endif
+#if __has_warning("-Wvariadic-macros")
+RAPIDJSON_DIAG_OFF(variadic-macros)
+#endif
 #elif defined(_MSC_VER)
 RAPIDJSON_DIAG_OFF(4512)  // assignment operator could not be generated
 #endif

--- a/3rdparty/rapidjson/stringbuffer.h
+++ b/3rdparty/rapidjson/stringbuffer.h
@@ -30,7 +30,9 @@
 
 #if defined(__clang__)
 RAPIDJSON_DIAG_PUSH
-RAPIDJSON_DIAG_OFF(c++ 98 - compat)
+#if __has_warning("-Wc++98-compat")
+RAPIDJSON_DIAG_OFF(c++98-compat)
+#endif
 #endif
 
 RAPIDJSON_NAMESPACE_BEGIN

--- a/3rdparty/rapidjson/writer.h
+++ b/3rdparty/rapidjson/writer.h
@@ -43,9 +43,15 @@
 
 #ifdef __clang__
 RAPIDJSON_DIAG_PUSH
+#if __has_warning("-Wpadded")
 RAPIDJSON_DIAG_OFF(padded)
-RAPIDJSON_DIAG_OFF(unreachable - code)
-RAPIDJSON_DIAG_OFF(c++ 98 - compat)
+#endif
+#if __has_warning("-Wc++98-compat")
+RAPIDJSON_DIAG_OFF(c++98-compat)
+#endif
+#if __has_warning("-Wunreachable-code")
+RAPIDJSON_DIAG_OFF(unreachable-code)
+#endif
 #elif defined(_MSC_VER)
 RAPIDJSON_DIAG_PUSH
 RAPIDJSON_DIAG_OFF(4127)  // conditional expression is constant

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -227,6 +227,8 @@ else(ROS_EDITION STREQUAL "ROS2")
   find_package(std_msgs REQUIRED)
   find_package(builtin_interfaces REQUIRED)
   find_package(rosidl_default_generators REQUIRED)
+  find_package(pcl_conversions REQUIRED)
+
 
   # check apr
   find_package(PkgConfig)
@@ -246,7 +248,7 @@ else(ROS_EDITION STREQUAL "ROS2")
   )
 
   ## make sure the livox_lidar_sdk_shared library is installed
-  find_library(LIVOX_LIDAR_SDK_LIBRARY liblivox_lidar_sdk_shared.so /usr/local/lib REQUIRED)
+  find_library(LIVOX_LIDAR_SDK_LIBRARY liblivox_lidar_sdk_shared.dylib /usr/local/lib REQUIRED)
 
   ##
   find_path(LIVOX_LIDAR_SDK_INCLUDE_DIR
@@ -283,24 +285,30 @@ else(ROS_EDITION STREQUAL "ROS2")
 
   # get include directories of custom msg headers
   if(HUMBLE_ROS STREQUAL "humble")
-    rosidl_get_typesupport_target(cpp_typesupport_target
+  rosidl_get_typesupport_target(cpp_typesupport_target
     ${LIVOX_INTERFACES} "rosidl_typesupport_cpp")
-    target_link_libraries(${PROJECT_NAME} "${cpp_typesupport_target}")
-  else()
-    set(LIVOX_INTERFACE_TARGET "${LIVOX_INTERFACES}__rosidl_typesupport_cpp")
-    add_dependencies(${PROJECT_NAME} ${LIVOX_INTERFACES})
-    get_target_property(LIVOX_INTERFACES_INCLUDE_DIRECTORIES ${LIVOX_INTERFACE_TARGET} INTERFACE_INCLUDE_DIRECTORIES)
-  endif()
+  target_link_libraries(${PROJECT_NAME} "${cpp_typesupport_target}")
+  get_target_property(LIVOX_INTERFACES_INCLUDE_DIRECTORIES ${LIVOX_INTERFACES} INTERFACE_INCLUDE_DIRECTORIES)
+else()
+  set(LIVOX_INTERFACE_TARGET "${LIVOX_INTERFACES}__rosidl_typesupport_cpp")
+  add_dependencies(${PROJECT_NAME} ${LIVOX_INTERFACES})
+  get_target_property(LIVOX_INTERFACES_INCLUDE_DIRECTORIES ${LIVOX_INTERFACE_TARGET} INTERFACE_INCLUDE_DIRECTORIES)
+endif()
 
-  # include file direcotry
-  target_include_directories(${PROJECT_NAME} PUBLIC
-    ${PCL_INCLUDE_DIRS}
-    ${APR_INCLUDE_DIRS}
-    ${LIVOX_LIDAR_SDK_INCLUDE_DIR}
-    ${LIVOX_INTERFACES_INCLUDE_DIRECTORIES}   # for custom msgs
-    3rdparty
-    src
-  )
+# もし LIVOX_INTERFACES_INCLUDE_DIRECTORIES が取得できなかった場合は、空文字列にする
+if(NOT LIVOX_INTERFACES_INCLUDE_DIRECTORIES)
+  set(LIVOX_INTERFACES_INCLUDE_DIRECTORIES "")
+endif()
+
+target_include_directories(${PROJECT_NAME} PUBLIC
+  ${PCL_INCLUDE_DIRS}
+  ${APR_INCLUDE_DIRS}
+  ${LIVOX_LIDAR_SDK_INCLUDE_DIR}
+  ${LIVOX_INTERFACES_INCLUDE_DIRECTORIES}   # for custom msgs (空の場合は無視される)
+  ${pcl_conversions_INCLUDE_DIRS}           # 追加：pcl_conversions のヘッダーをインクルード
+  3rdparty
+  src
+)
 
   # link libraries
   target_link_libraries(${PROJECT_NAME}

--- a/config/MID360_config.json
+++ b/config/MID360_config.json
@@ -11,13 +11,13 @@
       "log_data_port": 56500
     },
     "host_net_info" : {
-      "cmd_data_ip" : "192.168.1.5",
+      "cmd_data_ip" : "192.168.1.100",
       "cmd_data_port": 56101,
-      "push_msg_ip": "192.168.1.5",
+      "push_msg_ip": "192.168.1.100",
       "push_msg_port": 56201,
-      "point_data_ip": "192.168.1.5",
+      "point_data_ip": "192.168.1.100",
       "point_data_port": 56301,
-      "imu_data_ip" : "192.168.1.5",
+      "imu_data_ip" : "192.168.1.100",
       "imu_data_port": 56401,
       "log_data_ip" : "",
       "log_data_port": 56501
@@ -25,7 +25,7 @@
   },
   "lidar_configs" : [
     {
-      "ip" : "192.168.1.12",
+      "ip" : "192.168.1.115",
       "pcl_data_type" : 1,
       "pattern_mode" : 0,
       "extrinsic_parameter" : {


### PR DESCRIPTION
Hello maintainer.
I fix livox-SDK2 and livox_ros_driver2 and then I can use mid-360,  its sdk and rospackage!!

Summery is below(created by copilot)
- This pull request includes several changes to the `3rdparty/rapidjson` library to improve compatibility with different compilers, particularly Clang. The changes primarily involve adding conditional checks for specific warnings before disabling them.

### Improvements for Clang compatibility:

* [`3rdparty/rapidjson/document.h`](diffhunk://#diff-f59e584ac52b8c1bc433c223ddd1fdb03fad09f6234beaf1fd559c382371ae7fR34-R45): Added checks for `-Wpadded`, `-Wswitch-enum`, and `-Wc++98-compat` warnings before disabling them.
* [`3rdparty/rapidjson/filereadstream.h`](diffhunk://#diff-2eb9b9a140ca6875501a1140c14ebdc1fba7d2f2a9aaf4be72944311467ad7d3R27-R36): Added checks for `-Wpadded`, `-Wunreachable-code`, and `-Wmissing-noreturn` warnings before disabling them.
* [`3rdparty/rapidjson/schema.h`](diffhunk://#diff-a99dac044702c3d4ca21e48a24957721108c0d745494b313fee8358d7ea232bfR68-R79): Added checks for `-Wweak-vtables`, `-Wexit-time-destructors`, `-Wc++98-compat-pedantic`, and `-Wvariadic-macros` warnings before disabling them.
* [`3rdparty/rapidjson/reader.h`](diffhunk://#diff-3619c89b25243e00f9e47274a04f7a00e2a159090ea6bc406763ffca4d8999aaR47-R55): Added checks for `-Wold-style-cast`, `-Wpadded`, and `-Wswitch-enum` warnings before disabling them.
* [`3rdparty/rapidjson/writer.h`](diffhunk://#diff-50dcba87d0cdc201317193b16c193ac4c18b572971138f78a2c8153bfd8829d4R46-R54): Added checks for `-Wpadded`, `-Wc++98-compat`, and `-Wunreachable-code` warnings before disabling them.


In my environment, I can run this program on ROS 2 jazzy.
I don't use conda and pixi.
I use pyenv to create ros environment.

My environment
- M4 Macbook pro
- Mem 24GB
- MacOS 15.1.1
- pyenv python 3.11.8

<img width="1119" alt="スクリーンショット 2025-02-14 23 25 53" src="https://github.com/user-attachments/assets/3a4f75e6-9fa0-4239-99dd-bc37ee471090" />
