### PR TITLE
Fix: Update shared library search to be cross-platform

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -246,11 +246,7 @@ else(ROS_EDITION STREQUAL "ROS2")
   )
 
   ## make sure the livox_lidar_sdk_shared library is installed
-  if(APPLE)
-    find_library(LIVOX_LIDAR_SDK_LIBRARY liblivox_lidar_sdk_shared.dylib REQUIRED)
-  else()
-    find_library(LIVOX_LIDAR_SDK_LIBRARY liblivox_lidar_sdk_shared.so /usr/local/lib REQUIRED)
-  endif()
+  find_library(LIVOX_LIDAR_SDK_LIBRARY livox_lidar_sdk_shared HINTS /usr/local/lib REQUIRED)
 
   ##
   find_path(LIVOX_LIDAR_SDK_INCLUDE_DIR

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -246,7 +246,11 @@ else(ROS_EDITION STREQUAL "ROS2")
   )
 
   ## make sure the livox_lidar_sdk_shared library is installed
-  find_library(LIVOX_LIDAR_SDK_LIBRARY liblivox_lidar_sdk_shared.so /usr/local/lib REQUIRED)
+  if(APPLE)
+    find_library(LIVOX_LIDAR_SDK_LIBRARY liblivox_lidar_sdk_shared.dylib REQUIRED)
+  else()
+    find_library(LIVOX_LIDAR_SDK_LIBRARY liblivox_lidar_sdk_shared.so /usr/local/lib REQUIRED)
+  endif()
 
   ##
   find_path(LIVOX_LIDAR_SDK_INCLUDE_DIR


### PR DESCRIPTION
This pull request resolves a build issue where the `livox_lidar_sdk_shared` library could not be found on non-Apple platforms.

The original `find_library` command was hardcoded to search for a `.so` file, which is specific to `Linux.` This caused the build to fail on `macOS` systems, as the required shared library has a `.dylib` extension.