### PR TITLE
fix(comm): make imu extrinsics handling thread-safe (follow-up to #209)

### DIFF
--- a/src/comm/pub_handler.cpp
+++ b/src/comm/pub_handler.cpp
@@ -119,9 +119,17 @@ void PubHandler::OnLivoxLidarPointCloudCallback(uint32_t handle, const uint8_t d
       
       uint32_t id = 0;
       GetLidarId(LidarProtoType::kLivoxLidarType, handle, id);
-      const auto it = self->lidar_process_handlers_.find(id);
-      if (it != self->lidar_process_handlers_.end()) {
-        auto& e = it->second->GetDetailedLidarExtrinsics();
+      bool has_extrinsics = false;
+      ExtParameterDetailed e;
+      {
+        std::lock_guard<std::mutex> lock(self->lidar_process_handlers_mutex_);
+        const auto it = self->lidar_process_handlers_.find(id);
+        if (it != self->lidar_process_handlers_.end()) {
+          e = it->second->GetDetailedLidarExtrinsics();
+          has_extrinsics = true;
+        }
+      }
+      if (has_extrinsics) {
 
         // Take into account the lidar extrinsics.
         imu_data.gyro_x = (imu->gyro_x * e.rotation[0][0] +
@@ -192,7 +200,15 @@ void PubHandler::PublishPointCloud() {
 void PubHandler::CheckTimer(uint32_t id) {
 
   if (PubHandler::is_timestamp_sync_.load()) { // Enable time synchronization
-    auto& process_handler = lidar_process_handlers_[id];
+    LidarPubHandler* process_handler = nullptr;
+    {
+      std::lock_guard<std::mutex> lock(lidar_process_handlers_mutex_);
+      auto it = lidar_process_handlers_.find(id);
+      if (it == lidar_process_handlers_.end()) {
+        return;
+      }
+      process_handler = it->second.get();
+    }
     uint64_t recent_time_ms = process_handler->GetRecentTimeStamp() / kRatioOfMsToNs;
     if ((recent_time_ms % publish_interval_ms_ != 0) || recent_time_ms == 0) {
       return;
@@ -270,13 +286,32 @@ void PubHandler::RawDataProcess() {
     }
     uint32_t id = 0;
     GetLidarId(raw_data.lidar_type, raw_data.handle, id);
-    if (lidar_process_handlers_.find(id) == lidar_process_handlers_.end()) {
-      lidar_process_handlers_[id].reset(new LidarPubHandler());
+    LidarPubHandler* process_handler = nullptr;
+    {
+      std::lock_guard<std::mutex> lock(lidar_process_handlers_mutex_);
+      auto it = lidar_process_handlers_.find(id);
+      if (it == lidar_process_handlers_.end()) {
+        lidar_process_handlers_[id].reset(new LidarPubHandler());
+        it = lidar_process_handlers_.find(id);
+      }
+      process_handler = it->second.get();
     }
-    auto &process_handler = lidar_process_handlers_[id];
-    if (lidar_extrinsics_.find(id) != lidar_extrinsics_.end()) {
-        lidar_process_handlers_[id]->SetLidarsExtParam(lidar_extrinsics_[id]);
+
+    LidarExtParameter lidar_param = {};
+    bool has_lidar_extrinsics = false;
+    {
+      std::lock_guard<std::mutex> lock(packet_mutex_);
+      auto extrinsics_it = lidar_extrinsics_.find(id);
+      if (extrinsics_it != lidar_extrinsics_.end()) {
+        lidar_param = extrinsics_it->second;
+        has_lidar_extrinsics = true;
+      }
     }
+
+    if (has_lidar_extrinsics) {
+      process_handler->SetLidarsExtParam(lidar_param);
+    }
+
     process_handler->PointCloudProcess(raw_data);
     CheckTimer(id);
   }
@@ -362,6 +397,7 @@ void LidarPubHandler::LivoxLidarPointCloudProcess(RawPacket & pkt) {
 }
 
 void LidarPubHandler::SetLidarsExtParam(LidarExtParameter lidar_param) {
+  std::lock_guard<std::mutex> lock(extrinsic_mutex_);
   if (is_set_extrinsic_params_) {
     return;
   }
@@ -482,9 +518,9 @@ void LidarPubHandler::ProcessSphericalPoint(RawPacket& pkt) {
   }
 }
 
-const ExtParameterDetailed& LidarPubHandler::GetDetailedLidarExtrinsics() const {
+ExtParameterDetailed LidarPubHandler::GetDetailedLidarExtrinsics() const {
+  std::lock_guard<std::mutex> lock(extrinsic_mutex_);
   return extrinsic_;
 }
 
 } // namespace livox_ros
-

--- a/src/comm/pub_handler.cpp
+++ b/src/comm/pub_handler.cpp
@@ -116,7 +116,7 @@ void PubHandler::OnLivoxLidarPointCloudCallback(uint32_t handle, const uint8_t d
       imu_data.handle = handle;
       imu_data.time_stamp = GetEthPacketTimestamp(data->time_type,
                                                   data->timestamp, sizeof(data->timestamp));
-      // Take into account the lidar roll.
+      // Take into account the lidar extrinsics.
       imu_data.gyro_x = (imu->gyro_x * extrinsic_.rotation[0][0] +
                          imu->gyro_y * extrinsic_.rotation[0][1] +
                          imu->gyro_z * extrinsic_.rotation[0][2]);

--- a/src/comm/pub_handler.cpp
+++ b/src/comm/pub_handler.cpp
@@ -1,27 +1,3 @@
-//
-// The MIT License (MIT)
-//
-// Copyright (c) 2022 Livox. All rights reserved.
-//
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in
-// all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-// SOFTWARE.
-//
-
 #include "pub_handler.h"
 
 #include <cstdlib>
@@ -116,25 +92,40 @@ void PubHandler::OnLivoxLidarPointCloudCallback(uint32_t handle, const uint8_t d
       imu_data.handle = handle;
       imu_data.time_stamp = GetEthPacketTimestamp(data->time_type,
                                                   data->timestamp, sizeof(data->timestamp));
-      // Take into account the lidar extrinsics.
-      imu_data.gyro_x = (imu->gyro_x * extrinsic_.rotation[0][0] +
-                         imu->gyro_y * extrinsic_.rotation[0][1] +
-                         imu->gyro_z * extrinsic_.rotation[0][2]);
-      imu_data.gyro_y = (imu->gyro_x * extrinsic_.rotation[1][0] +
-                         imu->gyro_y * extrinsic_.rotation[1][1] +
-                         imu->gyro_z * extrinsic_.rotation[1][2]);
-      imu_data.gyro_z = (imu->gyro_x * extrinsic_.rotation[2][0] +
-                         imu->gyro_y * extrinsic_.rotation[2][1] +
-                         imu->gyro_z * extrinsic_.rotation[2][2]);
-      imu_data.acc_x = (imu->acc_x * extrinsic_.rotation[0][0] +
-                        imu->acc_y * extrinsic_.rotation[0][1] +
-                        imu->acc_z * extrinsic_.rotation[0][2]);
-      imu_data.acc_y = (imu->acc_x * extrinsic_.rotation[1][0] +
-                        imu->acc_y * extrinsic_.rotation[1][1] +
-                        imu->acc_z * extrinsic_.rotation[1][2]);
-      imu_data.acc_z = (imu->acc_x * extrinsic_.rotation[2][0] +
-                        imu->acc_y * extrinsic_.rotation[2][1] +
-                        imu->acc_z * extrinsic_.rotation[2][2]);
+      
+      uint32_t id = 0;
+      GetLidarId(LidarProtoType::kLivoxLidarType, handle, id);
+      const auto it = self->lidar_process_handlers_.find(id);
+      if (it != self->lidar_process_handlers_.end()) {
+        auto& e = it->second->GetDetailedLidarExtrinsics();
+
+        // Take into account the lidar extrinsics.
+        imu_data.gyro_x = (imu->gyro_x * e.rotation[0][0] +
+                          imu->gyro_y * e.rotation[0][1] +
+                          imu->gyro_z * e.rotation[0][2]);
+        imu_data.gyro_y = (imu->gyro_x * e.rotation[1][0] +
+                          imu->gyro_y * e.rotation[1][1] +
+                          imu->gyro_z * e.rotation[1][2]);
+        imu_data.gyro_z = (imu->gyro_x * e.rotation[2][0] +
+                          imu->gyro_y * e.rotation[2][1] +
+                          imu->gyro_z * e.rotation[2][2]);
+        imu_data.acc_x = (imu->acc_x * e.rotation[0][0] +
+                          imu->acc_y * e.rotation[0][1] +
+                          imu->acc_z * e.rotation[0][2]);
+        imu_data.acc_y = (imu->acc_x * e.rotation[1][0] +
+                          imu->acc_y * e.rotation[1][1] +
+                          imu->acc_z * e.rotation[1][2]);
+        imu_data.acc_z = (imu->acc_x * e.rotation[2][0] +
+                          imu->acc_y * e.rotation[2][1] +
+                          imu->acc_z * e.rotation[2][2]);
+      } else {
+        imu_data.gyro_x = imu->gyro_x;
+        imu_data.gyro_y = imu->gyro_y;
+        imu_data.gyro_z = imu->gyro_z;
+        imu_data.acc_x = imu->acc_x;
+        imu_data.acc_y = imu->acc_y;
+        imu_data.acc_z = imu->acc_z;
+      }
       self->imu_callback_(&imu_data, self->imu_client_data_);
     }
     return;
@@ -467,4 +458,9 @@ void LidarPubHandler::ProcessSphericalPoint(RawPacket& pkt) {
   }
 }
 
+const ExtParameterDetailed& LidarPubHandler::GetDetailedLidarExtrinsics() const {
+  return extrinsic_;
+}
+
 } // namespace livox_ros
+

--- a/src/comm/pub_handler.cpp
+++ b/src/comm/pub_handler.cpp
@@ -116,12 +116,25 @@ void PubHandler::OnLivoxLidarPointCloudCallback(uint32_t handle, const uint8_t d
       imu_data.handle = handle;
       imu_data.time_stamp = GetEthPacketTimestamp(data->time_type,
                                                   data->timestamp, sizeof(data->timestamp));
-      imu_data.gyro_x = imu->gyro_x;
-      imu_data.gyro_y = imu->gyro_y;
-      imu_data.gyro_z = imu->gyro_z;
-      imu_data.acc_x = imu->acc_x;
-      imu_data.acc_y = imu->acc_y;
-      imu_data.acc_z = imu->acc_z;
+      // Take into account the lidar roll.
+      imu_data.gyro_x = (imu->gyro_x * extrinsic_.rotation[0][0] +
+                         imu->gyro_y * extrinsic_.rotation[0][1] +
+                         imu->gyro_z * extrinsic_.rotation[0][2]);
+      imu_data.gyro_y = (imu->gyro_x * extrinsic_.rotation[1][0] +
+                         imu->gyro_y * extrinsic_.rotation[1][1] +
+                         imu->gyro_z * extrinsic_.rotation[1][2]);
+      imu_data.gyro_z = (imu->gyro_x * extrinsic_.rotation[2][0] +
+                         imu->gyro_y * extrinsic_.rotation[2][1] +
+                         imu->gyro_z * extrinsic_.rotation[2][2]);
+      imu_data.acc_x = (imu->acc_x * extrinsic_.rotation[0][0] +
+                        imu->acc_y * extrinsic_.rotation[0][1] +
+                        imu->acc_z * extrinsic_.rotation[0][2]);
+      imu_data.acc_y = (imu->acc_x * extrinsic_.rotation[1][0] +
+                        imu->acc_y * extrinsic_.rotation[1][1] +
+                        imu->acc_z * extrinsic_.rotation[1][2]);
+      imu_data.acc_z = (imu->acc_x * extrinsic_.rotation[2][0] +
+                        imu->acc_y * extrinsic_.rotation[2][1] +
+                        imu->acc_z * extrinsic_.rotation[2][2]);
       self->imu_callback_(&imu_data, self->imu_client_data_);
     }
     return;

--- a/src/comm/pub_handler.cpp
+++ b/src/comm/pub_handler.cpp
@@ -1,3 +1,27 @@
+//
+// The MIT License (MIT)
+//
+// Copyright (c) 2022 Livox. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+
 #include "pub_handler.h"
 
 #include <cstdlib>

--- a/src/comm/pub_handler.h
+++ b/src/comm/pub_handler.h
@@ -1,27 +1,3 @@
-//
-// The MIT License (MIT)
-//
-// Copyright (c) 2022 Livox. All rights reserved.
-//
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in
-// all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-// SOFTWARE.
-//
-
 #ifndef LIVOX_DRIVER_PUB_HANDLER_H_
 #define LIVOX_DRIVER_PUB_HANDLER_H_
 
@@ -53,6 +29,8 @@ class LidarPubHandler {
   uint64_t GetRecentTimeStamp();
   uint32_t GetLidarPointCloudsSize();
   uint64_t GetLidarBaseTime();
+
+  const ExtParameterDetailed& GetDetailedLidarExtrinsics() const;
 
  private:
   void LivoxLidarPointCloudProcess(RawPacket & pkt);
@@ -136,3 +114,4 @@ PubHandler &pub_handler();
 }  // namespace livox_ros
 
 #endif  // LIVOX_DRIVER_PUB_HANDLER_H_
+

--- a/src/comm/pub_handler.h
+++ b/src/comm/pub_handler.h
@@ -1,3 +1,27 @@
+//
+// The MIT License (MIT)
+//
+// Copyright (c) 2022 Livox. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+
 #ifndef LIVOX_DRIVER_PUB_HANDLER_H_
 #define LIVOX_DRIVER_PUB_HANDLER_H_
 

--- a/src/comm/pub_handler.h
+++ b/src/comm/pub_handler.h
@@ -54,7 +54,7 @@ class LidarPubHandler {
   uint32_t GetLidarPointCloudsSize();
   uint64_t GetLidarBaseTime();
 
-  const ExtParameterDetailed& GetDetailedLidarExtrinsics() const;
+  ExtParameterDetailed GetDetailedLidarExtrinsics() const;
 
  private:
   void LivoxLidarPointCloudProcess(RawPacket & pkt);
@@ -70,6 +70,7 @@ class LidarPubHandler {
       {0, 0, 1}
     }
   };
+  mutable std::mutex extrinsic_mutex_;
   std::mutex mutex_;
   std::atomic_bool is_set_extrinsic_params_;
 };
@@ -127,6 +128,7 @@ class PubHandler {
   TimePoint last_pub_time_;
 
   std::map<uint32_t, std::unique_ptr<LidarPubHandler>> lidar_process_handlers_;
+  std::mutex lidar_process_handlers_mutex_;
   std::map<uint32_t, std::vector<PointXyzlt>> points_;
   std::map<uint32_t, LidarExtParameter> lidar_extrinsics_;
   static std::atomic<bool> is_timestamp_sync_;
@@ -138,4 +140,3 @@ PubHandler &pub_handler();
 }  // namespace livox_ros
 
 #endif  // LIVOX_DRIVER_PUB_HANDLER_H_
-


### PR DESCRIPTION
Follow-up to #209.

This keeps the IMU extrinsics behavior introduced in #209, but fixes potential data races in multithreaded paths:

- Protect `lidar_process_handlers_` accesses with a dedicated mutex.
- Make `GetDetailedLidarExtrinsics()` return by value under lock.
- Guard `SetLidarsExtParam()` with the same extrinsics mutex.
- Read `lidar_extrinsics_` under `packet_mutex_` in `RawDataProcess()`.

This is intended as a behavior-preserving thread-safety fix.

cc @syaroshenko