### PR TITLE
move node parameters into private namespace

### DIFF
--- a/launch_ROS1/msg_HAP.launch
+++ b/launch_ROS1/msg_HAP.launch
@@ -16,21 +16,26 @@
 	<arg name="imu_bag" default="true"/>
 	<!--user configure parameters for ros end--> 
 
-	<param name="xfer_format" value="$(arg xfer_format)"/>
-	<param name="multi_topic" value="$(arg multi_topic)"/>
-	<param name="data_src" value="$(arg data_src)"/>
-	<param name="publish_freq" type="double" value="$(arg publish_freq)"/>
-	<param name="output_data_type" value="$(arg output_type)"/>
-	<param name="cmdline_str" type="string" value="$(arg bd_list)"/>
-	<param name="cmdline_file_path" type="string" value="$(arg lvx_file_path)"/>
-	<param name="user_config_path" type="string" value="$(find livox_ros_driver2)/config/HAP_config.json"/>
-	<param name="frame_id" type="string" value="$(arg msg_frame_id)"/>
-	<param name="enable_lidar_bag" type="bool" value="$(arg lidar_bag)"/>
-	<param name="enable_imu_bag" type="bool" value="$(arg imu_bag)"/>
-
-	<node name="livox_lidar_publisher2" pkg="livox_ros_driver2"
-	      type="livox_ros_driver2_node" required="true"
-	      output="screen" args="$(arg cmdline_arg)"/>
+	<node
+			name="livox_lidar_publisher2"
+			pkg="livox_ros_driver2"
+	     	type="livox_ros_driver2_node"
+			required="true"
+	      	output="screen"
+			args="$(arg cmdline_arg)"
+	>
+		<param name="xfer_format"                     value="$(arg xfer_format)"/>
+		<param name="multi_topic"                     value="$(arg multi_topic)"/>
+		<param name="data_src"                        value="$(arg data_src)"/>
+		<param name="publish_freq"      type="double" value="$(arg publish_freq)"/>
+		<param name="output_data_type"                value="$(arg output_type)"/>
+		<param name="cmdline_str"       type="string" value="$(arg bd_list)"/>
+		<param name="cmdline_file_path" type="string" value="$(arg lvx_file_path)"/>
+		<param name="user_config_path"  type="string" value="$(find livox_ros_driver2)/config/HAP_config.json"/>
+		<param name="frame_id"          type="string" value="$(arg msg_frame_id)"/>
+		<param name="enable_lidar_bag"  type="bool"   value="$(arg lidar_bag)"/>
+		<param name="enable_imu_bag"    type="bool"   value="$(arg imu_bag)"/>
+	</node>
 
 	<group if="$(arg rosbag_enable)">
     	<node pkg="rosbag" type="record" name="record" output="screen"

--- a/launch_ROS1/msg_MID360.launch
+++ b/launch_ROS1/msg_MID360.launch
@@ -16,21 +16,26 @@
 	<arg name="imu_bag" default="true"/>
 	<!--user configure parameters for ros end--> 
 
-	<param name="xfer_format" value="$(arg xfer_format)"/>
-	<param name="multi_topic" value="$(arg multi_topic)"/>
-	<param name="data_src" value="$(arg data_src)"/>
-	<param name="publish_freq" type="double" value="$(arg publish_freq)"/>
-	<param name="output_data_type" value="$(arg output_type)"/>
-	<param name="cmdline_str" type="string" value="$(arg bd_list)"/>
-	<param name="cmdline_file_path" type="string" value="$(arg lvx_file_path)"/>
-	<param name="user_config_path" type="string" value="$(find livox_ros_driver2)/config/MID360_config.json"/>
-	<param name="frame_id" type="string" value="$(arg msg_frame_id)"/>
-	<param name="enable_lidar_bag" type="bool" value="$(arg lidar_bag)"/>
-	<param name="enable_imu_bag" type="bool" value="$(arg imu_bag)"/>
-
-	<node name="livox_lidar_publisher2" pkg="livox_ros_driver2"
-	      type="livox_ros_driver2_node" required="true"
-	      output="screen" args="$(arg cmdline_arg)"/>
+	<node
+			name="livox_lidar_publisher2"
+			pkg="livox_ros_driver2"
+	      	type="livox_ros_driver2_node"
+			required="true"
+	      	output="screen"
+			args="$(arg cmdline_arg)"
+	>
+		<param name="xfer_format"                     value="$(arg xfer_format)"/>
+		<param name="multi_topic"                     value="$(arg multi_topic)"/>
+		<param name="data_src"                        value="$(arg data_src)"/>
+		<param name="publish_freq"      type="double" value="$(arg publish_freq)"/>
+		<param name="output_data_type"                value="$(arg output_type)"/>
+		<param name="cmdline_str"       type="string" value="$(arg bd_list)"/>
+		<param name="cmdline_file_path" type="string" value="$(arg lvx_file_path)"/>
+		<param name="user_config_path"  type="string" value="$(find livox_ros_driver2)/config/MID360_config.json"/>
+		<param name="frame_id"          type="string" value="$(arg msg_frame_id)"/>
+		<param name="enable_lidar_bag"  type="bool"   value="$(arg lidar_bag)"/>
+		<param name="enable_imu_bag"    type="bool"   value="$(arg imu_bag)"/>
+	</node>
 
 	<group if="$(arg rosbag_enable)">
     	<node pkg="rosbag" type="record" name="record" output="screen"

--- a/launch_ROS1/msg_mixed.launch
+++ b/launch_ROS1/msg_mixed.launch
@@ -16,21 +16,26 @@
 	<arg name="imu_bag" default="true"/>
 	<!--user configure parameters for ros end--> 
 
-	<param name="xfer_format" value="$(arg xfer_format)"/>
-	<param name="multi_topic" value="$(arg multi_topic)"/>
-	<param name="data_src" value="$(arg data_src)"/>
-	<param name="publish_freq" type="double" value="$(arg publish_freq)"/>
-	<param name="output_data_type" value="$(arg output_type)"/>
-	<param name="cmdline_str" type="string" value="$(arg bd_list)"/>
-	<param name="cmdline_file_path" type="string" value="$(arg lvx_file_path)"/>
-	<param name="user_config_path" type="string" value="$(find livox_ros_driver2)/config/mixed_HAP_MID360_config.json"/>
-	<param name="frame_id" type="string" value="$(arg msg_frame_id)"/>
-	<param name="enable_lidar_bag" type="bool" value="$(arg lidar_bag)"/>
-	<param name="enable_imu_bag" type="bool" value="$(arg imu_bag)"/>
-
-	<node name="livox_lidar_publisher2" pkg="livox_ros_driver2"
-	      type="livox_ros_driver2_node" required="true"
-	      output="screen" args="$(arg cmdline_arg)"/>
+	<node
+			name="livox_lidar_publisher2"
+			pkg="livox_ros_driver2"
+	      	type="livox_ros_driver2_node"
+			required="true"
+	      	output="screen"
+			args="$(arg cmdline_arg)"
+	>
+		<param name="xfer_format"                     value="$(arg xfer_format)"/>
+		<param name="multi_topic"                     value="$(arg multi_topic)"/>
+		<param name="data_src"                        value="$(arg data_src)"/>
+		<param name="publish_freq"      type="double" value="$(arg publish_freq)"/>
+		<param name="output_data_type"                value="$(arg output_type)"/>
+		<param name="cmdline_str"       type="string" value="$(arg bd_list)"/>
+		<param name="cmdline_file_path" type="string" value="$(arg lvx_file_path)"/>
+		<param name="user_config_path"  type="string" value="$(find livox_ros_driver2)/config/mixed_HAP_MID360_config.json"/>
+		<param name="frame_id"          type="string" value="$(arg msg_frame_id)"/>
+		<param name="enable_lidar_bag"  type="bool"   value="$(arg lidar_bag)"/>
+		<param name="enable_imu_bag"    type="bool"   value="$(arg imu_bag)"/>
+	</node>
 
 	<group if="$(arg rosbag_enable)">
     	<node pkg="rosbag" type="record" name="record" output="screen"

--- a/launch_ROS1/rviz_HAP.launch
+++ b/launch_ROS1/rviz_HAP.launch
@@ -16,21 +16,26 @@
 	<arg name="imu_bag" default="true"/>
 	<!--user configure parameters for ros end--> 
 
-	<param name="xfer_format" value="$(arg xfer_format)"/>
-	<param name="multi_topic" value="$(arg multi_topic)"/>
-	<param name="data_src" value="$(arg data_src)"/>
-	<param name="publish_freq" type="double" value="$(arg publish_freq)"/>
-	<param name="output_data_type" value="$(arg output_type)"/>
-	<param name="cmdline_str" type="string" value="$(arg bd_list)"/>
-	<param name="cmdline_file_path" type="string" value="$(arg lvx_file_path)"/>
-	<param name="user_config_path" type="string" value="$(find livox_ros_driver2)/config/HAP_config.json"/>
-	<param name="frame_id" type="string" value="$(arg msg_frame_id)"/>
-	<param name="enable_lidar_bag" type="bool" value="$(arg lidar_bag)"/>
-	<param name="enable_imu_bag" type="bool" value="$(arg imu_bag)"/>
-
-	<node name="livox_lidar_publisher2" pkg="livox_ros_driver2"
-	      type="livox_ros_driver2_node" required="true"
-	      output="screen" args="$(arg cmdline_arg)"/>
+	<node
+			name="livox_lidar_publisher2"
+			pkg="livox_ros_driver2"
+	      	type="livox_ros_driver2_node"
+			required="true"
+	      	output="screen"
+			args="$(arg cmdline_arg)"
+	>
+		<param name="xfer_format"                     value="$(arg xfer_format)"/>
+		<param name="multi_topic"                     value="$(arg multi_topic)"/>
+		<param name="data_src"                        value="$(arg data_src)"/>
+		<param name="publish_freq"      type="double" value="$(arg publish_freq)"/>
+		<param name="output_data_type"                value="$(arg output_type)"/>
+		<param name="cmdline_str"       type="string" value="$(arg bd_list)"/>
+		<param name="cmdline_file_path" type="string" value="$(arg lvx_file_path)"/>
+		<param name="user_config_path"  type="string" value="$(find livox_ros_driver2)/config/HAP_config.json"/>
+		<param name="frame_id"          type="string" value="$(arg msg_frame_id)"/>
+		<param name="enable_lidar_bag"  type="bool"   value="$(arg lidar_bag)"/>
+		<param name="enable_imu_bag"    type="bool"   value="$(arg imu_bag)"/>
+	</node>
 
 	<group if="$(arg rviz_enable)">
 		<node name="livox_rviz" pkg="rviz" type="rviz" respawn="true"

--- a/launch_ROS1/rviz_MID360.launch
+++ b/launch_ROS1/rviz_MID360.launch
@@ -16,21 +16,26 @@
 	<arg name="imu_bag" default="true"/>
 	<!--user configure parameters for ros end--> 
 
-	<param name="xfer_format" value="$(arg xfer_format)"/>
-	<param name="multi_topic" value="$(arg multi_topic)"/>
-	<param name="data_src" value="$(arg data_src)"/>
-	<param name="publish_freq" type="double" value="$(arg publish_freq)"/>
-	<param name="output_data_type" value="$(arg output_type)"/>
-	<param name="cmdline_str" type="string" value="$(arg bd_list)"/>
-	<param name="cmdline_file_path" type="string" value="$(arg lvx_file_path)"/>
-	<param name="user_config_path" type="string" value="$(find livox_ros_driver2)/config/MID360_config.json"/>
-	<param name="frame_id" type="string" value="$(arg msg_frame_id)"/>
-	<param name="enable_lidar_bag" type="bool" value="$(arg lidar_bag)"/>
-	<param name="enable_imu_bag" type="bool" value="$(arg imu_bag)"/>
-
-	<node name="livox_lidar_publisher2" pkg="livox_ros_driver2"
-	      type="livox_ros_driver2_node" required="true"
-	      output="screen" args="$(arg cmdline_arg)"/>
+	<node
+			name="livox_lidar_publisher2"
+			pkg="livox_ros_driver2"
+	      	type="livox_ros_driver2_node"
+			required="true"
+	      	output="screen"
+			args="$(arg cmdline_arg)"
+	>
+		<param name="xfer_format"                     value="$(arg xfer_format)"/>
+		<param name="multi_topic"                     value="$(arg multi_topic)"/>
+		<param name="data_src"                        value="$(arg data_src)"/>
+		<param name="publish_freq"      type="double" value="$(arg publish_freq)"/>
+		<param name="output_data_type"                value="$(arg output_type)"/>
+		<param name="cmdline_str"       type="string" value="$(arg bd_list)"/>
+		<param name="cmdline_file_path" type="string" value="$(arg lvx_file_path)"/>
+		<param name="user_config_path"  type="string" value="$(find livox_ros_driver2)/config/MID360_config.json"/>
+		<param name="frame_id"          type="string" value="$(arg msg_frame_id)"/>
+		<param name="enable_lidar_bag"  type="bool"   value="$(arg lidar_bag)"/>
+		<param name="enable_imu_bag"    type="bool"   value="$(arg imu_bag)"/>
+	</node>
 
 	<group if="$(arg rviz_enable)">
 		<node name="livox_rviz" pkg="rviz" type="rviz" respawn="true"

--- a/launch_ROS1/rviz_mixed.launch
+++ b/launch_ROS1/rviz_mixed.launch
@@ -16,21 +16,26 @@
 	<arg name="imu_bag" default="true"/>
 	<!--user configure parameters for ros end--> 
 
-	<param name="xfer_format" value="$(arg xfer_format)"/>
-	<param name="multi_topic" value="$(arg multi_topic)"/>
-	<param name="data_src" value="$(arg data_src)"/>
-	<param name="publish_freq" type="double" value="$(arg publish_freq)"/>
-	<param name="output_data_type" value="$(arg output_type)"/>
-	<param name="cmdline_str" type="string" value="$(arg bd_list)"/>
-	<param name="cmdline_file_path" type="string" value="$(arg lvx_file_path)"/>
-	<param name="user_config_path" type="string" value="$(find livox_ros_driver2)/config/mixed_HAP_MID360_config.json"/>
-	<param name="frame_id" type="string" value="$(arg msg_frame_id)"/>
-	<param name="enable_lidar_bag" type="bool" value="$(arg lidar_bag)"/>
-	<param name="enable_imu_bag" type="bool" value="$(arg imu_bag)"/>
-
-	<node name="livox_lidar_publisher2" pkg="livox_ros_driver2"
-	      type="livox_ros_driver2_node" required="true"
-	      output="screen" args="$(arg cmdline_arg)"/>
+	<node
+			name="livox_lidar_publisher2"
+			pkg="livox_ros_driver2"
+	      	type="livox_ros_driver2_node"
+			required="true"
+	      	output="screen"
+			args="$(arg cmdline_arg)"
+	>
+		<param name="xfer_format"                     value="$(arg xfer_format)"/>
+		<param name="multi_topic"                     value="$(arg multi_topic)"/>
+		<param name="data_src"                        value="$(arg data_src)"/>
+		<param name="publish_freq"      type="double" value="$(arg publish_freq)"/>
+		<param name="output_data_type"                value="$(arg output_type)"/>
+		<param name="cmdline_str"       type="string" value="$(arg bd_list)"/>
+		<param name="cmdline_file_path" type="string" value="$(arg lvx_file_path)"/>
+		<param name="user_config_path"  type="string" value="$(find livox_ros_driver2)/config/mixed_HAP_MID360_config.json"/>
+		<param name="frame_id"          type="string" value="$(arg msg_frame_id)"/>
+		<param name="enable_lidar_bag"  type="bool"   value="$(arg lidar_bag)"/>
+		<param name="enable_imu_bag"    type="bool"   value="$(arg imu_bag)"/>
+	</node>
 
 	<group if="$(arg rviz_enable)">
 		<node name="livox_rviz" pkg="rviz" type="rviz" respawn="true"

--- a/src/livox_ros_driver2.cpp
+++ b/src/livox_ros_driver2.cpp
@@ -60,14 +60,16 @@ int main(int argc, char **argv) {
   bool lidar_bag = true;
   bool imu_bag   = false;
 
-  livox_node.GetNode().getParam("xfer_format", xfer_format);
-  livox_node.GetNode().getParam("multi_topic", multi_topic);
-  livox_node.GetNode().getParam("data_src", data_src);
-  livox_node.GetNode().getParam("publish_freq", publish_freq);
-  livox_node.GetNode().getParam("output_data_type", output_type);
-  livox_node.GetNode().getParam("frame_id", frame_id);
-  livox_node.GetNode().getParam("enable_lidar_bag", lidar_bag);
-  livox_node.GetNode().getParam("enable_imu_bag", imu_bag);
+  ros::NodeHandle pnh("~");
+
+  pnh.getParam("xfer_format", xfer_format);
+  pnh.getParam("multi_topic", multi_topic);
+  pnh.getParam("data_src", data_src);
+  pnh.getParam("publish_freq", publish_freq);
+  pnh.getParam("output_data_type", output_type);
+  pnh.getParam("frame_id", frame_id);
+  pnh.getParam("enable_lidar_bag", lidar_bag);
+  pnh.getParam("enable_imu_bag", imu_bag);
 
   printf("data source:%u.\n", data_src);
 
@@ -90,7 +92,7 @@ int main(int argc, char **argv) {
     DRIVER_INFO(livox_node, "Data Source is raw lidar.");
 
     std::string user_config_path;
-    livox_node.getParam("user_config_path", user_config_path);
+    pnh.getParam("user_config_path", user_config_path);
     DRIVER_INFO(livox_node, "Config file : %s", user_config_path.c_str());
 
     LdsLidar *read_lidar = LdsLidar::GetInstance(publish_freq);


### PR DESCRIPTION
Parameters are now loaded from the node’s private namespace, which avoids unintended mixing or overriding of parameters from other nodes.