### PR TITLE
Feature/multi lidar unique frame

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ LiDAR Configurations (such as ip, port, data type... etc.) can be set via a json
       "ip" : "192.168.1.100",  # ip of the LiDAR you want to config
       "pcl_data_type" : 1,
       "pattern_mode" : 0,
+      "frame_id" : "livox_hap_frame",
       "blind_spot_set" : 50,
       "extrinsic_parameter" : {
         "roll": 0.0,
@@ -253,9 +254,10 @@ The parameter attributes in the above json file are described in the following t
 **LiDAR configuration parameter**
 | Parameter                  | Type    | Description                                                  | Default         |
 | :------------------------- | ------- | ------------------------------------------------------------ | --------------- |
-| ip             | String  | Ip of the LiDAR you want to config | 192.168.1.100 |
-| pcl_data_type             | Int | Choose the resolution of the point cloud data to send<br>1 -- Cartesian coordinate data (32 bits)<br>2 -- Cartesian coordinate data (16 bits) <br>3 --Spherical coordinate data| 1           |
-| pattern_mode                | Int     | Space scan pattern<br>0 -- non-repeating scanning pattern mode<br>1 -- repeating scanning pattern mode <br>2 -- repeating scanning pattern mode (low scanning rate) | 0               |
+| ip             | String    | Ip of the LiDAR you want to config | 192.168.1.100 |
+| pcl_data_type              | Int | Choose the resolution of the point cloud data to send<br>1 -- Cartesian coordinate data (32 bits)<br>2 -- Cartesian coordinate data (16 bits) <br>3 --Spherical coordinate data| 1           |
+| pattern_mode               | Int     | Space scan pattern<br>0 -- non-repeating scanning pattern mode<br>1 -- repeating scanning pattern mode <br>2 -- repeating scanning pattern mode (low scanning rate) | 0               |
+| frame_id                   | String  | LiDAR's frame ID in PointCloud2 and other ROS messages       | livox_lidar     |
 | blind_spot_set (Only for HAP LiDAR)                 | Int     | Set blind spot<br>Range from 50 cm to 200 cm               | 50               |
 | extrinsic_parameter |      | Set extrinsic parameter<br> The data types of "roll" "picth" "yaw" are float <br>  The data types of "x" "y" "z" are int<br>               |
 
@@ -316,6 +318,7 @@ For more infomation about the HAP config, please refer to:
       "ip" : "192.168.1.100",  # ip of the HAP you want to config
       "pcl_data_type" : 1,
       "pattern_mode" : 0,
+      "frame_id" : "livox_hap_frame",
       "blind_spot_set" : 50,
       "extrinsic_parameter" : {
         "roll": 0.0,
@@ -330,6 +333,7 @@ For more infomation about the HAP config, please refer to:
       "ip" : "192.168.1.12",  # ip of the Mid360 you want to config
       "pcl_data_type" : 1,
       "pattern_mode" : 0,
+      "frame_id" : "livox_mid360_frame",
       "extrinsic_parameter" : {
         "roll": 0.0,
         "pitch": 0.0,
@@ -375,6 +379,7 @@ For more infomation about the HAP config, please refer to:
             "ip": "192.168.1.100", # ip of the LiDAR you want to config
             "pcl_data_type": 1,
             "pattern_mode": 0,
+            "frame_id" : "livox_mid360_frame1",
             "extrinsic_parameter": {
                 "roll": 0.0,
                 "pitch": 0.0,
@@ -418,6 +423,7 @@ For more infomation about the HAP config, please refer to:
             "ip": "192.168.2.100", # ip of the LiDAR you want to config
             "pcl_data_type": 1,
             "pattern_mode": 0,
+            "frame_id" : "livox_mid360_frame2",
             "extrinsic_parameter": {
                 "roll": 0.0,
                 "pitch": 0.0,

--- a/README.md
+++ b/README.md
@@ -444,7 +444,6 @@ For more infomation about the HAP config, please refer to:
     <arg name="rviz_enable" default="true"/>
     <arg name="rosbag_enable" default="false"/>
     <arg name="cmdline_arg" default="$(arg bd_list)"/>
-    <arg name="msg_frame_id" default="livox_frame"/>
     <arg name="lidar_bag" default="true"/>
     <arg name="imu_bag" default="true"/>
     <!--user configure parameters for ros end--> 
@@ -457,7 +456,6 @@ For more infomation about the HAP config, please refer to:
     <param name="cmdline_str" type="string" value="$(arg bd_list)"/>
     <param name="cmdline_file_path" type="string" value="$(arg lvx_file_path)"/>
     <param name="user_config_path" type="string" value="$(find livox_ros_driver2)/config/MID360_config1.json"/> # Mid360 MID360_config1 name
-    <param name="frame_id" type="string" value="$(arg msg_frame_id)"/>
     <param name="enable_lidar_bag" type="bool" value="$(arg lidar_bag)"/>
     <param name="enable_imu_bag" type="bool" value="$(arg imu_bag)"/>
 
@@ -491,7 +489,6 @@ For more infomation about the HAP config, please refer to:
     <arg name="rviz_enable" default="true"/>
     <arg name="rosbag_enable" default="false"/>
     <arg name="cmdline_arg" default="$(arg bd_list)"/>
-    <arg name="msg_frame_id" default="livox_frame"/>
     <arg name="lidar_bag" default="true"/>
     <arg name="imu_bag" default="true"/>
     <!--user configure parameters for ros end--> 
@@ -504,7 +501,6 @@ For more infomation about the HAP config, please refer to:
     <param name="cmdline_str" type="string" value="$(arg bd_list)"/>
     <param name="cmdline_file_path" type="string" value="$(arg lvx_file_path)"/>
     <param name="user_config_path" type="string" value="$(find livox_ros_driver2)/config/MID360_config2.json"/> # Mid360 MID360_config2 name
-    <param name="frame_id" type="string" value="$(arg msg_frame_id)"/>
     <param name="enable_lidar_bag" type="bool" value="$(arg lidar_bag)"/>
     <param name="enable_imu_bag" type="bool" value="$(arg imu_bag)"/>
 

--- a/config/HAP_config.json
+++ b/config/HAP_config.json
@@ -28,6 +28,7 @@
       "ip" : "192.168.1.100",
       "pcl_data_type" : 1,
       "pattern_mode" : 0,
+      "frame_id" : "livox_hap_frame",
       "extrinsic_parameter" : {
         "roll": 0.0,
         "pitch": 0.0,

--- a/config/MID360_config.json
+++ b/config/MID360_config.json
@@ -28,6 +28,7 @@
       "ip" : "192.168.1.12",
       "pcl_data_type" : 1,
       "pattern_mode" : 0,
+      "frame_id" : "livox_mid360_frame",
       "extrinsic_parameter" : {
         "roll": 0.0,
         "pitch": 0.0,

--- a/config/MID360s_config.json
+++ b/config/MID360s_config.json
@@ -26,6 +26,7 @@
       "ip" : "192.168.1.12",
       "pcl_data_type" : 1,
       "pattern_mode" : 0,
+      "frame_id" : "livox_mid360s_frame",
       "extrinsic_parameter" : {
         "roll": 0.0,
         "pitch": 0.0,

--- a/config/mixed_HAP_MID360_config.json
+++ b/config/mixed_HAP_MID360_config.json
@@ -49,6 +49,7 @@
       "ip" : "192.168.1.100",
       "pcl_data_type" : 1,
       "pattern_mode" : 0,
+      "frame_id" : "livox_hap_frame",
       "extrinsic_parameter" : {
         "roll": 0.0,
         "pitch": 0.0,
@@ -62,6 +63,7 @@
       "ip" : "192.168.1.12",
       "pcl_data_type" : 1,
       "pattern_mode" : 0,
+      "frame_id" : "livox_mid360_frame",
       "extrinsic_parameter" : {
         "roll": 0.0,
         "pitch": 0.0,

--- a/launch_ROS1/msg_HAP.launch
+++ b/launch_ROS1/msg_HAP.launch
@@ -11,7 +11,6 @@
 	<arg name="rviz_enable" default="false"/>
 	<arg name="rosbag_enable" default="false"/>
 	<arg name="cmdline_arg" default="$(arg bd_list)"/>
-	<arg name="msg_frame_id" default="livox_frame"/>
 	<arg name="lidar_bag" default="true"/>
 	<arg name="imu_bag" default="true"/>
 	<!--user configure parameters for ros end--> 
@@ -24,7 +23,6 @@
 	<param name="cmdline_str" type="string" value="$(arg bd_list)"/>
 	<param name="cmdline_file_path" type="string" value="$(arg lvx_file_path)"/>
 	<param name="user_config_path" type="string" value="$(find livox_ros_driver2)/config/HAP_config.json"/>
-	<param name="frame_id" type="string" value="$(arg msg_frame_id)"/>
 	<param name="enable_lidar_bag" type="bool" value="$(arg lidar_bag)"/>
 	<param name="enable_imu_bag" type="bool" value="$(arg imu_bag)"/>
 

--- a/launch_ROS1/msg_MID360.launch
+++ b/launch_ROS1/msg_MID360.launch
@@ -11,7 +11,6 @@
 	<arg name="rviz_enable" default="false"/>
 	<arg name="rosbag_enable" default="false"/>
 	<arg name="cmdline_arg" default="$(arg bd_list)"/>
-	<arg name="msg_frame_id" default="livox_frame"/>
 	<arg name="lidar_bag" default="true"/>
 	<arg name="imu_bag" default="true"/>
 	<!--user configure parameters for ros end--> 
@@ -24,7 +23,6 @@
 	<param name="cmdline_str" type="string" value="$(arg bd_list)"/>
 	<param name="cmdline_file_path" type="string" value="$(arg lvx_file_path)"/>
 	<param name="user_config_path" type="string" value="$(find livox_ros_driver2)/config/MID360_config.json"/>
-	<param name="frame_id" type="string" value="$(arg msg_frame_id)"/>
 	<param name="enable_lidar_bag" type="bool" value="$(arg lidar_bag)"/>
 	<param name="enable_imu_bag" type="bool" value="$(arg imu_bag)"/>
 

--- a/launch_ROS1/msg_MID360s.launch
+++ b/launch_ROS1/msg_MID360s.launch
@@ -11,7 +11,6 @@
 	<arg name="rviz_enable" default="false"/>
 	<arg name="rosbag_enable" default="false"/>
 	<arg name="cmdline_arg" default="$(arg bd_list)"/>
-	<arg name="msg_frame_id" default="livox_frame"/>
 	<arg name="lidar_bag" default="true"/>
 	<arg name="imu_bag" default="true"/>
 	<!--user configure parameters for ros end--> 
@@ -24,7 +23,6 @@
 	<param name="cmdline_str" type="string" value="$(arg bd_list)"/>
 	<param name="cmdline_file_path" type="string" value="$(arg lvx_file_path)"/>
 	<param name="user_config_path" type="string" value="$(find livox_ros_driver2)/config/MID360s_config.json"/>
-	<param name="frame_id" type="string" value="$(arg msg_frame_id)"/>
 	<param name="enable_lidar_bag" type="bool" value="$(arg lidar_bag)"/>
 	<param name="enable_imu_bag" type="bool" value="$(arg imu_bag)"/>
 

--- a/launch_ROS1/msg_mixed.launch
+++ b/launch_ROS1/msg_mixed.launch
@@ -11,7 +11,6 @@
 	<arg name="rviz_enable" default="false"/>
 	<arg name="rosbag_enable" default="false"/>
 	<arg name="cmdline_arg" default="$(arg bd_list)"/>
-	<arg name="msg_frame_id" default="livox_frame"/>
 	<arg name="lidar_bag" default="true"/>
 	<arg name="imu_bag" default="true"/>
 	<!--user configure parameters for ros end--> 
@@ -24,7 +23,6 @@
 	<param name="cmdline_str" type="string" value="$(arg bd_list)"/>
 	<param name="cmdline_file_path" type="string" value="$(arg lvx_file_path)"/>
 	<param name="user_config_path" type="string" value="$(find livox_ros_driver2)/config/mixed_HAP_MID360_config.json"/>
-	<param name="frame_id" type="string" value="$(arg msg_frame_id)"/>
 	<param name="enable_lidar_bag" type="bool" value="$(arg lidar_bag)"/>
 	<param name="enable_imu_bag" type="bool" value="$(arg imu_bag)"/>
 

--- a/launch_ROS1/rviz_HAP.launch
+++ b/launch_ROS1/rviz_HAP.launch
@@ -11,7 +11,6 @@
 	<arg name="rviz_enable" default="true"/>
 	<arg name="rosbag_enable" default="false"/>
 	<arg name="cmdline_arg" default="$(arg bd_list)"/>
-	<arg name="msg_frame_id" default="livox_frame"/>
 	<arg name="lidar_bag" default="true"/>
 	<arg name="imu_bag" default="true"/>
 	<!--user configure parameters for ros end--> 
@@ -24,7 +23,6 @@
 	<param name="cmdline_str" type="string" value="$(arg bd_list)"/>
 	<param name="cmdline_file_path" type="string" value="$(arg lvx_file_path)"/>
 	<param name="user_config_path" type="string" value="$(find livox_ros_driver2)/config/HAP_config.json"/>
-	<param name="frame_id" type="string" value="$(arg msg_frame_id)"/>
 	<param name="enable_lidar_bag" type="bool" value="$(arg lidar_bag)"/>
 	<param name="enable_imu_bag" type="bool" value="$(arg imu_bag)"/>
 

--- a/launch_ROS1/rviz_MID360.launch
+++ b/launch_ROS1/rviz_MID360.launch
@@ -11,7 +11,6 @@
 	<arg name="rviz_enable" default="true"/>
 	<arg name="rosbag_enable" default="false"/>
 	<arg name="cmdline_arg" default="$(arg bd_list)"/>
-	<arg name="msg_frame_id" default="livox_frame"/>
 	<arg name="lidar_bag" default="true"/>
 	<arg name="imu_bag" default="true"/>
 	<!--user configure parameters for ros end--> 
@@ -24,7 +23,6 @@
 	<param name="cmdline_str" type="string" value="$(arg bd_list)"/>
 	<param name="cmdline_file_path" type="string" value="$(arg lvx_file_path)"/>
 	<param name="user_config_path" type="string" value="$(find livox_ros_driver2)/config/MID360_config.json"/>
-	<param name="frame_id" type="string" value="$(arg msg_frame_id)"/>
 	<param name="enable_lidar_bag" type="bool" value="$(arg lidar_bag)"/>
 	<param name="enable_imu_bag" type="bool" value="$(arg imu_bag)"/>
 

--- a/launch_ROS1/rviz_MID360s.launch
+++ b/launch_ROS1/rviz_MID360s.launch
@@ -11,7 +11,6 @@
 	<arg name="rviz_enable" default="true"/>
 	<arg name="rosbag_enable" default="false"/>
 	<arg name="cmdline_arg" default="$(arg bd_list)"/>
-	<arg name="msg_frame_id" default="livox_frame"/>
 	<arg name="lidar_bag" default="true"/>
 	<arg name="imu_bag" default="true"/>
 	<!--user configure parameters for ros end--> 
@@ -24,7 +23,6 @@
 	<param name="cmdline_str" type="string" value="$(arg bd_list)"/>
 	<param name="cmdline_file_path" type="string" value="$(arg lvx_file_path)"/>
 	<param name="user_config_path" type="string" value="$(find livox_ros_driver2)/config/MID360s_config.json"/>
-	<param name="frame_id" type="string" value="$(arg msg_frame_id)"/>
 	<param name="enable_lidar_bag" type="bool" value="$(arg lidar_bag)"/>
 	<param name="enable_imu_bag" type="bool" value="$(arg imu_bag)"/>
 

--- a/launch_ROS1/rviz_mixed.launch
+++ b/launch_ROS1/rviz_mixed.launch
@@ -11,7 +11,6 @@
 	<arg name="rviz_enable" default="true"/>
 	<arg name="rosbag_enable" default="false"/>
 	<arg name="cmdline_arg" default="$(arg bd_list)"/>
-	<arg name="msg_frame_id" default="livox_frame"/>
 	<arg name="lidar_bag" default="true"/>
 	<arg name="imu_bag" default="true"/>
 	<!--user configure parameters for ros end--> 
@@ -24,7 +23,6 @@
 	<param name="cmdline_str" type="string" value="$(arg bd_list)"/>
 	<param name="cmdline_file_path" type="string" value="$(arg lvx_file_path)"/>
 	<param name="user_config_path" type="string" value="$(find livox_ros_driver2)/config/mixed_HAP_MID360_config.json"/>
-	<param name="frame_id" type="string" value="$(arg msg_frame_id)"/>
 	<param name="enable_lidar_bag" type="bool" value="$(arg lidar_bag)"/>
 	<param name="enable_imu_bag" type="bool" value="$(arg imu_bag)"/>
 

--- a/launch_ROS2/msg_HAP_launch.py
+++ b/launch_ROS2/msg_HAP_launch.py
@@ -10,7 +10,6 @@ multi_topic   = 0    # 0-All LiDARs share the same topic, 1-One LiDAR one topic
 data_src      = 0    # 0-lidar, others-Invalid data src
 publish_freq  = 10.0 # freqency of publish, 5.0, 10.0, 20.0, 50.0, etc.
 output_type   = 0
-frame_id      = 'livox_frame'
 lvx_file_path = '/home/livox/livox_test.lvx'
 cmdline_bd_code = 'livox0000000001'
 
@@ -26,7 +25,6 @@ livox_ros2_params = [
     {"data_src": data_src},
     {"publish_freq": publish_freq},
     {"output_data_type": output_type},
-    {"frame_id": frame_id},
     {"lvx_file_path": lvx_file_path},
     {"user_config_path": user_config_path},
     {"cmdline_input_bd_code": cmdline_bd_code}

--- a/launch_ROS2/msg_MID360_launch.py
+++ b/launch_ROS2/msg_MID360_launch.py
@@ -10,7 +10,6 @@ multi_topic   = 0    # 0-All LiDARs share the same topic, 1-One LiDAR one topic
 data_src      = 0    # 0-lidar, others-Invalid data src
 publish_freq  = 10.0 # freqency of publish, 5.0, 10.0, 20.0, 50.0, etc.
 output_type   = 0
-frame_id      = 'livox_frame'
 lvx_file_path = '/home/livox/livox_test.lvx'
 cmdline_bd_code = 'livox0000000001'
 
@@ -25,7 +24,6 @@ livox_ros2_params = [
     {"data_src": data_src},
     {"publish_freq": publish_freq},
     {"output_data_type": output_type},
-    {"frame_id": frame_id},
     {"lvx_file_path": lvx_file_path},
     {"user_config_path": user_config_path},
     {"cmdline_input_bd_code": cmdline_bd_code}

--- a/launch_ROS2/msg_MID360s_launch.py
+++ b/launch_ROS2/msg_MID360s_launch.py
@@ -10,7 +10,6 @@ multi_topic   = 0    # 0-All LiDARs share the same topic, 1-One LiDAR one topic
 data_src      = 0    # 0-lidar, others-Invalid data src
 publish_freq  = 10.0 # freqency of publish, 5.0, 10.0, 20.0, 50.0, etc.
 output_type   = 0
-frame_id      = 'livox_frame'
 lvx_file_path = '/home/livox/livox_test.lvx'
 cmdline_bd_code = 'livox0000000001'
 
@@ -25,7 +24,6 @@ livox_ros2_params = [
     {"data_src": data_src},
     {"publish_freq": publish_freq},
     {"output_data_type": output_type},
-    {"frame_id": frame_id},
     {"lvx_file_path": lvx_file_path},
     {"user_config_path": user_config_path},
     {"cmdline_input_bd_code": cmdline_bd_code}

--- a/launch_ROS2/rviz_HAP_launch.py
+++ b/launch_ROS2/rviz_HAP_launch.py
@@ -10,7 +10,6 @@ multi_topic   = 0    # 0-All LiDARs share the same topic, 1-One LiDAR one topic
 data_src      = 0    # 0-lidar, others-Invalid data src
 publish_freq  = 10.0 # freqency of publish, 5.0, 10.0, 20.0, 50.0, etc.
 output_type   = 0
-frame_id      = 'livox_frame'
 lvx_file_path = '/home/livox/livox_test.lvx'
 cmdline_bd_code = 'livox0000000001'
 
@@ -26,7 +25,6 @@ livox_ros2_params = [
     {"data_src": data_src},
     {"publish_freq": publish_freq},
     {"output_data_type": output_type},
-    {"frame_id": frame_id},
     {"lvx_file_path": lvx_file_path},
     {"user_config_path": user_config_path},
     {"cmdline_input_bd_code": cmdline_bd_code}

--- a/launch_ROS2/rviz_MID360_launch.py
+++ b/launch_ROS2/rviz_MID360_launch.py
@@ -10,7 +10,6 @@ multi_topic   = 0    # 0-All LiDARs share the same topic, 1-One LiDAR one topic
 data_src      = 0    # 0-lidar, others-Invalid data src
 publish_freq  = 10.0 # freqency of publish, 5.0, 10.0, 20.0, 50.0, etc.
 output_type   = 0
-frame_id      = 'livox_frame'
 lvx_file_path = '/home/livox/livox_test.lvx'
 cmdline_bd_code = 'livox0000000001'
 
@@ -26,7 +25,6 @@ livox_ros2_params = [
     {"data_src": data_src},
     {"publish_freq": publish_freq},
     {"output_data_type": output_type},
-    {"frame_id": frame_id},
     {"lvx_file_path": lvx_file_path},
     {"user_config_path": user_config_path},
     {"cmdline_input_bd_code": cmdline_bd_code}

--- a/launch_ROS2/rviz_MID360s_launch.py
+++ b/launch_ROS2/rviz_MID360s_launch.py
@@ -10,7 +10,6 @@ multi_topic   = 0    # 0-All LiDARs share the same topic, 1-One LiDAR one topic
 data_src      = 0    # 0-lidar, others-Invalid data src
 publish_freq  = 10.0 # freqency of publish, 5.0, 10.0, 20.0, 50.0, etc.
 output_type   = 0
-frame_id      = 'livox_frame'
 lvx_file_path = '/home/livox/livox_test.lvx'
 cmdline_bd_code = 'livox0000000001'
 
@@ -26,7 +25,6 @@ livox_ros2_params = [
     {"data_src": data_src},
     {"publish_freq": publish_freq},
     {"output_data_type": output_type},
-    {"frame_id": frame_id},
     {"lvx_file_path": lvx_file_path},
     {"user_config_path": user_config_path},
     {"cmdline_input_bd_code": cmdline_bd_code}

--- a/launch_ROS2/rviz_mixed.py
+++ b/launch_ROS2/rviz_mixed.py
@@ -10,7 +10,6 @@ multi_topic   = 0    # 0-All LiDARs share the same topic, 1-One LiDAR one topic
 data_src      = 0    # 0-lidar, others-Invalid data src
 publish_freq  = 10.0 # freqency of publish, 5.0, 10.0, 20.0, 50.0, etc.
 output_type   = 0
-frame_id      = 'livox_frame'
 lvx_file_path = '/home/livox/livox_test.lvx'
 cmdline_bd_code = 'livox0000000001'
 
@@ -26,7 +25,6 @@ livox_ros2_params = [
     {"data_src": data_src},
     {"publish_freq": publish_freq},
     {"output_data_type": output_type},
-    {"frame_id": frame_id},
     {"lvx_file_path": lvx_file_path},
     {"user_config_path": user_config_path},
     {"cmdline_input_bd_code": cmdline_bd_code}

--- a/src/comm/comm.h
+++ b/src/comm/comm.h
@@ -264,6 +264,7 @@ typedef struct {
   int8_t pattern_mode;
   int32_t blind_spot_set;
   int8_t dual_emit_en;
+  std::string frame_id;
   ExtParameter extrinsic_param;
   volatile uint32_t set_bits;
   volatile uint32_t get_bits;

--- a/src/lddc.cpp
+++ b/src/lddc.cpp
@@ -167,11 +167,11 @@ void Lddc::PollingLidarPointCloudData(uint8_t index, LidarDevice *lidar) {
 
   while (!lds_->IsRequestExit() && !QueueIsEmpty(p_queue)) {
     if (kPointCloud2Msg == transfer_format_) {
-      PublishPointcloud2(p_queue, index);
+      PublishPointcloud2(p_queue, index, lidar->livox_config.frame_id);
     } else if (kLivoxCustomMsg == transfer_format_) {
-      PublishCustomPointcloud(p_queue, index);
+      PublishCustomPointcloud(p_queue, index, lidar->livox_config.frame_id);
     } else if (kPclPxyziMsg == transfer_format_) {
-      PublishPclMsg(p_queue, index);
+      PublishPclMsg(p_queue, index, lidar->livox_config.frame_id);
     }
   }
 }
@@ -179,7 +179,7 @@ void Lddc::PollingLidarPointCloudData(uint8_t index, LidarDevice *lidar) {
 void Lddc::PollingLidarImuData(uint8_t index, LidarDevice *lidar) {
   LidarImuDataQueue& p_queue = lidar->imu_data;
   while (!lds_->IsRequestExit() && !p_queue.Empty()) {
-    PublishImuData(p_queue, index);
+    PublishImuData(p_queue, index, lidar->livox_config.frame_id);
   }
 }
 
@@ -198,7 +198,7 @@ void Lddc::PrepareExit(void) {
   }
 }
 
-void Lddc::PublishPointcloud2(LidarDataQueue *queue, uint8_t index) {
+void Lddc::PublishPointcloud2(LidarDataQueue *queue, uint8_t index, const std::string& frame_id) {
   while(!QueueIsEmpty(queue)) {
     StoragePacket pkg;
     QueuePop(queue, &pkg);
@@ -209,12 +209,12 @@ void Lddc::PublishPointcloud2(LidarDataQueue *queue, uint8_t index) {
 
     PointCloud2 cloud;
     uint64_t timestamp = 0;
-    InitPointcloud2Msg(pkg, cloud, timestamp);
+    InitPointcloud2Msg(pkg, cloud, timestamp, frame_id);
     PublishPointcloud2Data(index, timestamp, cloud);
   }
 }
 
-void Lddc::PublishCustomPointcloud(LidarDataQueue *queue, uint8_t index) {
+void Lddc::PublishCustomPointcloud(LidarDataQueue *queue, uint8_t index, const std::string& frame_id) {
   while(!QueueIsEmpty(queue)) {
     StoragePacket pkg;
     QueuePop(queue, &pkg);
@@ -224,14 +224,14 @@ void Lddc::PublishCustomPointcloud(LidarDataQueue *queue, uint8_t index) {
     }
 
     CustomMsg livox_msg;
-    InitCustomMsg(livox_msg, pkg, index);
+    InitCustomMsg(livox_msg, pkg, index, frame_id);
     FillPointsToCustomMsg(livox_msg, pkg);
     PublishCustomPointData(livox_msg, index);
   }
 }
 
 /* for pcl::pxyzi */
-void Lddc::PublishPclMsg(LidarDataQueue *queue, uint8_t index) {
+void Lddc::PublishPclMsg(LidarDataQueue *queue, uint8_t index, const std::string& frame_id) {
 #ifdef BUILDING_ROS2
   static bool first_log = true;
   if (first_log) {
@@ -252,15 +252,15 @@ void Lddc::PublishPclMsg(LidarDataQueue *queue, uint8_t index) {
 
     PointCloud cloud;
     uint64_t timestamp = 0;
-    InitPclMsg(pkg, cloud, timestamp);
+    InitPclMsg(pkg, cloud, timestamp, frame_id);
     FillPointsToPclMsg(pkg, cloud);
     PublishPclData(index, timestamp, cloud);
   }
   return;
 }
 
-void Lddc::InitPointcloud2MsgHeader(PointCloud2& cloud) {
-  cloud.header.frame_id.assign(frame_id_);
+void Lddc::InitPointcloud2MsgHeader(PointCloud2& cloud, const std::string& frame_id) {
+  cloud.header.frame_id.assign(frame_id);
   cloud.height = 1;
   cloud.width = 0;
   cloud.fields.resize(7);
@@ -295,8 +295,8 @@ void Lddc::InitPointcloud2MsgHeader(PointCloud2& cloud) {
   cloud.point_step = sizeof(LivoxPointXyzrtlt);
 }
 
-void Lddc::InitPointcloud2Msg(const StoragePacket& pkg, PointCloud2& cloud, uint64_t& timestamp) {
-  InitPointcloud2MsgHeader(cloud);
+void Lddc::InitPointcloud2Msg(const StoragePacket& pkg, PointCloud2& cloud, uint64_t& timestamp, const std::string& frame_id) {
+  InitPointcloud2MsgHeader(cloud, frame_id);
 
   cloud.point_step = sizeof(LivoxPointXyzrtlt);
 
@@ -351,8 +351,8 @@ void Lddc::PublishPointcloud2Data(const uint8_t index, const uint64_t timestamp,
   }
 }
 
-void Lddc::InitCustomMsg(CustomMsg& livox_msg, const StoragePacket& pkg, uint8_t index) {
-  livox_msg.header.frame_id.assign(frame_id_);
+void Lddc::InitCustomMsg(CustomMsg& livox_msg, const StoragePacket& pkg, uint8_t index, const std::string& frame_id) {
+  livox_msg.header.frame_id.assign(frame_id);
 
 #ifdef BUILDING_ROS1
   static uint32_t msg_seq = 0;
@@ -416,9 +416,9 @@ void Lddc::PublishCustomPointData(const CustomMsg& livox_msg, const uint8_t inde
   }
 }
 
-void Lddc::InitPclMsg(const StoragePacket& pkg, PointCloud& cloud, uint64_t& timestamp) {
+void Lddc::InitPclMsg(const StoragePacket& pkg, PointCloud& cloud, uint64_t& timestamp, const std::string& frame_id) {
 #ifdef BUILDING_ROS1
-  cloud.header.frame_id.assign(frame_id_);
+  cloud.header.frame_id.assign(frame_id);
   cloud.height = 1;
   cloud.width = pkg.points_num;
 
@@ -477,8 +477,8 @@ void Lddc::PublishPclData(const uint8_t index, const uint64_t timestamp, const P
   return;
 }
 
-void Lddc::InitImuMsg(const ImuData& imu_data, ImuMsg& imu_msg, uint64_t& timestamp) {
-  imu_msg.header.frame_id = "livox_frame";
+void Lddc::InitImuMsg(const ImuData& imu_data, ImuMsg& imu_msg, uint64_t& timestamp, const std::string& frame_id) {
+  imu_msg.header.frame_id = frame_id;
 
   timestamp = imu_data.time_stamp;
 #ifdef BUILDING_ROS1
@@ -495,7 +495,7 @@ void Lddc::InitImuMsg(const ImuData& imu_data, ImuMsg& imu_msg, uint64_t& timest
   imu_msg.linear_acceleration.z = imu_data.acc_z;
 }
 
-void Lddc::PublishImuData(LidarImuDataQueue& imu_data_queue, const uint8_t index) {
+void Lddc::PublishImuData(LidarImuDataQueue& imu_data_queue, const uint8_t index, const std::string& frame_id) {
   ImuData imu_data;
   if (!imu_data_queue.Pop(imu_data)) {
     //printf("Publish imu data failed, imu data queue pop failed.\n");
@@ -504,7 +504,7 @@ void Lddc::PublishImuData(LidarImuDataQueue& imu_data_queue, const uint8_t index
 
   ImuMsg imu_msg;
   uint64_t timestamp;
-  InitImuMsg(imu_data, imu_msg, timestamp);
+  InitImuMsg(imu_data, imu_msg, timestamp, frame_id);
 
 #ifdef BUILDING_ROS1
   PublisherPtr publisher_ptr = GetCurrentImuPublisher(index);

--- a/src/lddc.cpp
+++ b/src/lddc.cpp
@@ -42,13 +42,12 @@ namespace livox_ros {
 /** Lidar Data Distribute Control--------------------------------------------*/
 #ifdef BUILDING_ROS1
 Lddc::Lddc(int format, int multi_topic, int data_src, int output_type,
-    double frq, std::string &frame_id, bool lidar_bag, bool imu_bag)
+    double frq, bool lidar_bag, bool imu_bag)
     : transfer_format_(format),
       use_multi_topic_(multi_topic),
       data_src_(data_src),
       output_type_(output_type),
       publish_frq_(frq),
-      frame_id_(frame_id),
       enable_lidar_bag_(lidar_bag),
       enable_imu_bag_(imu_bag) {
   publish_period_ns_ = kNsPerSecond / publish_frq_;
@@ -62,13 +61,12 @@ Lddc::Lddc(int format, int multi_topic, int data_src, int output_type,
 }
 #elif defined BUILDING_ROS2
 Lddc::Lddc(int format, int multi_topic, int data_src, int output_type,
-           double frq, std::string &frame_id)
+           double frq)
     : transfer_format_(format),
       use_multi_topic_(multi_topic),
       data_src_(data_src),
       output_type_(output_type),
-      publish_frq_(frq),
-      frame_id_(frame_id) {
+      publish_frq_(frq) {
   publish_period_ns_ = kNsPerSecond / publish_frq_;
   lds_ = nullptr;
 #if 0

--- a/src/lddc.h
+++ b/src/lddc.h
@@ -29,6 +29,7 @@
 
 #include "driver_node.h"
 #include "lds.h"
+#include <string>
 
 namespace livox_ros {
 
@@ -100,25 +101,25 @@ class Lddc final {
   void PollingLidarPointCloudData(uint8_t index, LidarDevice *lidar);
   void PollingLidarImuData(uint8_t index, LidarDevice *lidar);
 
-  void PublishPointcloud2(LidarDataQueue *queue, uint8_t index);
-  void PublishCustomPointcloud(LidarDataQueue *queue, uint8_t index);
-  void PublishPclMsg(LidarDataQueue *queue, uint8_t index);
+  void PublishPointcloud2(LidarDataQueue *queue, uint8_t index, const std::string& frame_id);
+  void PublishCustomPointcloud(LidarDataQueue *queue, uint8_t index, const std::string& frame_id);
+  void PublishPclMsg(LidarDataQueue *queue, uint8_t index, const std::string& frame_id);
 
-  void PublishImuData(LidarImuDataQueue& imu_data_queue, const uint8_t index);
+  void PublishImuData(LidarImuDataQueue& imu_data_queue, const uint8_t index, const std::string& frame_id);
 
-  void InitPointcloud2MsgHeader(PointCloud2& cloud);
-  void InitPointcloud2Msg(const StoragePacket& pkg, PointCloud2& cloud, uint64_t& timestamp);
+  void InitPointcloud2MsgHeader(PointCloud2& cloud, const std::string& frame_id);
+  void InitPointcloud2Msg(const StoragePacket& pkg, PointCloud2& cloud, uint64_t& timestamp, const std::string& frame_id);
   void PublishPointcloud2Data(const uint8_t index, uint64_t timestamp, const PointCloud2& cloud);
 
-  void InitCustomMsg(CustomMsg& livox_msg, const StoragePacket& pkg, uint8_t index);
+  void InitCustomMsg(CustomMsg& livox_msg, const StoragePacket& pkg, uint8_t index, const std::string& frame_id);
   void FillPointsToCustomMsg(CustomMsg& livox_msg, const StoragePacket& pkg);
   void PublishCustomPointData(const CustomMsg& livox_msg, const uint8_t index);
 
-  void InitPclMsg(const StoragePacket& pkg, PointCloud& cloud, uint64_t& timestamp);
+  void InitPclMsg(const StoragePacket& pkg, PointCloud& cloud, uint64_t& timestamp, const std::string& frame_id);
   void FillPointsToPclMsg(const StoragePacket& pkg, PointCloud& pcl_msg);
   void PublishPclData(const uint8_t index, const uint64_t timestamp, const PointCloud& cloud);
 
-  void InitImuMsg(const ImuData& imu_data, ImuMsg& imu_msg, uint64_t& timestamp);
+  void InitImuMsg(const ImuData& imu_data, ImuMsg& imu_msg, uint64_t& timestamp, const std::string& frame_id);
 
   void FillPointsToPclMsg(PointCloud& pcl_msg, LivoxPointXyzrtlt* src_point, uint32_t num);
   void FillPointsToCustomMsg(CustomMsg& livox_msg, LivoxPointXyzrtlt* src_point, uint32_t num,

--- a/src/lddc.h
+++ b/src/lddc.h
@@ -74,10 +74,9 @@ class Lddc final {
  public:
 #ifdef BUILDING_ROS1
   Lddc(int format, int multi_topic, int data_src, int output_type, double frq,
-      std::string &frame_id, bool lidar_bag, bool imu_bag);
+      bool lidar_bag, bool imu_bag);
 #elif defined BUILDING_ROS2
-  Lddc(int format, int multi_topic, int data_src, int output_type, double frq,
-      std::string &frame_id);
+  Lddc(int format, int multi_topic, int data_src, int output_type, double frq);
 #endif
   ~Lddc();
 
@@ -139,7 +138,6 @@ class Lddc final {
   uint8_t output_type_;
   double publish_frq_;
   uint32_t publish_period_ns_;
-  std::string frame_id_;
 
 #ifdef BUILDING_ROS1
   bool enable_lidar_bag_;

--- a/src/livox_ros_driver2.cpp
+++ b/src/livox_ros_driver2.cpp
@@ -56,7 +56,6 @@ int main(int argc, char **argv) {
   int data_src = kSourceRawLidar;
   double publish_freq  = 10.0; /* Hz */
   int output_type      = kOutputToRos;
-  std::string frame_id = "livox_frame";
   bool lidar_bag = true;
   bool imu_bag   = false;
 
@@ -65,7 +64,6 @@ int main(int argc, char **argv) {
   livox_node.GetNode().getParam("data_src", data_src);
   livox_node.GetNode().getParam("publish_freq", publish_freq);
   livox_node.GetNode().getParam("output_data_type", output_type);
-  livox_node.GetNode().getParam("frame_id", frame_id);
   livox_node.GetNode().getParam("enable_lidar_bag", lidar_bag);
   livox_node.GetNode().getParam("enable_imu_bag", imu_bag);
 
@@ -83,7 +81,7 @@ int main(int argc, char **argv) {
 
   /** Lidar data distribute control and lidar data source set */
   livox_node.lddc_ptr_ = std::make_unique<Lddc>(xfer_format, multi_topic, data_src, output_type,
-                        publish_freq, frame_id, lidar_bag, imu_bag);
+                        publish_freq, lidar_bag, imu_bag);
   livox_node.lddc_ptr_->SetRosNode(&livox_node);
 
   if (data_src == kSourceRawLidar) {
@@ -126,14 +124,12 @@ DriverNode::DriverNode(const rclcpp::NodeOptions & node_options)
   int data_src = kSourceRawLidar;
   double publish_freq = 10.0; /* Hz */
   int output_type = kOutputToRos;
-  std::string frame_id;
 
   this->declare_parameter("xfer_format", xfer_format);
   this->declare_parameter("multi_topic", 0);
   this->declare_parameter("data_src", data_src);
   this->declare_parameter("publish_freq", 10.0);
   this->declare_parameter("output_data_type", output_type);
-  this->declare_parameter("frame_id", "frame_default");
   this->declare_parameter("user_config_path", "path_default");
   this->declare_parameter("cmdline_input_bd_code", "000000000000001");
   this->declare_parameter("lvx_file_path", "/home/livox/livox_test.lvx");
@@ -143,7 +139,6 @@ DriverNode::DriverNode(const rclcpp::NodeOptions & node_options)
   this->get_parameter("data_src", data_src);
   this->get_parameter("publish_freq", publish_freq);
   this->get_parameter("output_data_type", output_type);
-  this->get_parameter("frame_id", frame_id);
 
   if (publish_freq > 100.0) {
     publish_freq = 100.0;
@@ -156,7 +151,7 @@ DriverNode::DriverNode(const rclcpp::NodeOptions & node_options)
   future_ = exit_signal_.get_future();
 
   /** Lidar data distribute control and lidar data source set */
-  lddc_ptr_ = std::make_unique<Lddc>(xfer_format, multi_topic, data_src, output_type, publish_freq, frame_id);
+  lddc_ptr_ = std::make_unique<Lddc>(xfer_format, multi_topic, data_src, output_type, publish_freq);
   lddc_ptr_->SetRosNode(this);
 
   if (data_src == kSourceRawLidar) {

--- a/src/parse_cfg_file/parse_livox_lidar_cfg.cpp
+++ b/src/parse_cfg_file/parse_livox_lidar_cfg.cpp
@@ -92,6 +92,12 @@ bool LivoxLidarConfigParser::ParseUserConfigs(const rapidjson::Document &doc,
     } else {
       user_config.dual_emit_en = static_cast<uint8_t>(config["dual_emit_en"].GetInt());
     }
+    if (!config.HasMember("frame_id")) {
+      user_config.frame_id = "livox_lidar";
+      std::cout << "No frame id was given, set to default of 'livox_lidar'" << std::endl;
+    } else {
+      user_config.frame_id = static_cast<std::string>(config["frame_id"].GetString());
+    }
     if (!config.HasMember("extrinsic_parameter")) {
       memset(&user_config.extrinsic_param, 0, sizeof(user_config.extrinsic_param));
     } else {


### PR DESCRIPTION
Configure multiple lidar multiple frame_id in the configuration file, remove "frame_id" option from ROS parameters to JSON config.

This is modified [PR](https://github.com/Livox-SDK/livox_ros_driver2/pull/85) version, where changed only frame_id parameter logic.