### PR TITLE
Add Mid-70 config and launch files

### DIFF
--- a/config/MID70_config.json
+++ b/config/MID70_config.json
@@ -1,0 +1,41 @@
+{
+  "lidar_summary_info" : {
+    "lidar_type": 6
+  },
+  "MID70": {
+    "lidar_net_info" : {
+      "cmd_data_port": 56100,
+      "push_msg_port": 56200,
+      "point_data_port": 56300,
+      "imu_data_port": 56400,
+      "log_data_port": 56500
+    },
+    "host_net_info" : {
+      "cmd_data_ip" : "192.168.1.5",
+      "cmd_data_port": 56101,
+      "push_msg_ip": "192.168.1.5",
+      "push_msg_port": 56201,
+      "point_data_ip": "192.168.1.5",
+      "point_data_port": 56301,
+      "imu_data_ip" : "192.168.1.5",
+      "imu_data_port": 56401,
+      "log_data_ip" : "",
+      "log_data_port": 56501
+    }
+  },
+  "lidar_configs" : [
+    {
+      "ip" : "192.168.1.12",
+      "pcl_data_type" : 1,
+      "pattern_mode" : 0,
+      "extrinsic_parameter" : {
+        "roll": 0.0,
+        "pitch": 0.0,
+        "yaw": 0.0,
+        "x": 0,
+        "y": 0,
+        "z": 0
+      }
+    }
+  ]
+}

--- a/launch_ROS2/msg_MID70_launch.py
+++ b/launch_ROS2/msg_MID70_launch.py
@@ -1,0 +1,46 @@
+import os
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch_ros.actions import Node
+import launch
+
+################### user configure parameters for ros2 start ###################
+xfer_format   = 1    # 0-Pointcloud2(PointXYZRTL), 1-customized pointcloud format
+multi_topic   = 0    # 0-All LiDARs share the same topic, 1-One LiDAR one topic
+data_src      = 0    # 0-lidar, others-Invalid data src
+publish_freq  = 10.0 # freqency of publish, 5.0, 10.0, 20.0, 50.0, etc.
+output_type   = 0
+frame_id      = 'livox_frame'
+lvx_file_path = '/home/livox/livox_test.lvx'
+cmdline_bd_code = 'livox0000000001'
+
+cur_path = os.path.split(os.path.realpath(__file__))[0] + '/'
+cur_config_path = cur_path + '../config'
+user_config_path = os.path.join(cur_config_path, 'MID70_config.json')
+################### user configure parameters for ros2 end #####################
+
+livox_ros2_params = [
+    {"xfer_format": xfer_format},
+    {"multi_topic": multi_topic},
+    {"data_src": data_src},
+    {"publish_freq": publish_freq},
+    {"output_data_type": output_type},
+    {"frame_id": frame_id},
+    {"lvx_file_path": lvx_file_path},
+    {"user_config_path": user_config_path},
+    {"cmdline_input_bd_code": cmdline_bd_code}
+]
+
+
+def generate_launch_description():
+    livox_driver = Node(
+        package='livox_ros_driver2',
+        executable='livox_ros_driver2_node',
+        name='livox_lidar_publisher',
+        output='screen',
+        parameters=livox_ros2_params
+        )
+
+    return LaunchDescription([
+        livox_driver,
+    ])

--- a/launch_ROS2/rviz_MID70_launch.py
+++ b/launch_ROS2/rviz_MID70_launch.py
@@ -1,0 +1,55 @@
+import os
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch_ros.actions import Node
+import launch
+
+################### user configure parameters for ros2 start ###################
+xfer_format   = 0    # 0-Pointcloud2(PointXYZRTL), 1-customized pointcloud format
+multi_topic   = 0    # 0-All LiDARs share the same topic, 1-One LiDAR one topic
+data_src      = 0    # 0-lidar, others-Invalid data src
+publish_freq  = 10.0 # freqency of publish, 5.0, 10.0, 20.0, 50.0, etc.
+output_type   = 0
+frame_id      = 'livox_frame'
+lvx_file_path = '/home/livox/livox_test.lvx'
+cmdline_bd_code = 'livox0000000001'
+
+cur_path = os.path.split(os.path.realpath(__file__))[0] + '/'
+cur_config_path = cur_path + '../config'
+rviz_config_path = os.path.join(cur_config_path, 'display_point_cloud_ROS2.rviz')
+user_config_path = os.path.join(cur_config_path, 'MID70_config.json')
+################### user configure parameters for ros2 end #####################
+
+livox_ros2_params = [
+    {"xfer_format": xfer_format},
+    {"multi_topic": multi_topic},
+    {"data_src": data_src},
+    {"publish_freq": publish_freq},
+    {"output_data_type": output_type},
+    {"frame_id": frame_id},
+    {"lvx_file_path": lvx_file_path},
+    {"user_config_path": user_config_path},
+    {"cmdline_input_bd_code": cmdline_bd_code}
+]
+
+
+def generate_launch_description():
+    livox_driver = Node(
+        package='livox_ros_driver2',
+        executable='livox_ros_driver2_node',
+        name='livox_lidar_publisher',
+        output='screen',
+        parameters=livox_ros2_params
+        )
+
+    livox_rviz = Node(
+            package='rviz2',
+            executable='rviz2',
+            output='screen',
+            arguments=['--display-config', rviz_config_path]
+        )
+
+    return LaunchDescription([
+        livox_driver,
+        livox_rviz,
+    ])


### PR DESCRIPTION
## Summary

Add Mid-70 LiDAR configuration and launch files to livox_ros_driver2.

## New files
- `config/MID70_config.json` — Mid-70 JSON config (`lidar_type: 6`, port scheme 56100-56501)
- `launch_ROS2/msg_MID70_launch.py` — ROS2 launch (custom msg format, no RViz)
- `launch_ROS2/rviz_MID70_launch.py` — ROS2 launch with RViz2

## Dependencies
Requires the corresponding Mid-70 SDK2 changes in [Livox-SDK2#PR](https://github.com/Livox-SDK/Livox-SDK2).