### PR TITLE
feat: add ROS2 Kilted build support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -282,7 +282,7 @@ else(ROS_EDITION STREQUAL "ROS2")
   target_include_directories(${PROJECT_NAME} PRIVATE ${livox_sdk_INCLUDE_DIRS})
 
   # get include directories of custom msg headers
-  if(DISTRO_ROS STREQUAL "humble" OR DISTRO_ROS STREQUAL "jazzy")
+  if(DISTRO_ROS STREQUAL "humble" OR DISTRO_ROS STREQUAL "jazzy" OR DISTRO_ROS STREQUAL "kilted")
     rosidl_get_typesupport_target(cpp_typesupport_target
     ${LIVOX_INTERFACES} "rosidl_typesupport_cpp")
     target_link_libraries(${PROJECT_NAME} "${cpp_typesupport_target}")

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Livox ROS Driver 2 is the 2nd-generation driver package used to connect LiDAR pr
   * Ubuntu 20.04 for ROS Noetic and ROS2 Foxy;
   * Ubuntu 22.04 for ROS2 Humble;
   * Ubuntu 24.04 for ROS 2 Jazzy;
+  * Ubuntu 24.04 for ROS 2 Kilted;
 
   **Tips:**
 
@@ -37,6 +38,9 @@ For ROS2 Humble installation, please refer to:
 
 For ROS2 Jazzy installation, please refer to:
 [ROS Jazzy installation instructions](https://docs.ros.org/en/jazzy/Installation/Ubuntu-Install-Debians.html)
+
+For ROS2 Kilted installation, please refer to:
+[ROS Kilted installation instructions](https://docs.ros.org/en/kilted/Installation/Ubuntu-Install-Debians.html)
 
 
 Desktop-Full installation is recommend.
@@ -84,6 +88,13 @@ source /opt/ros/humble/setup.sh
 ```shell
 source /opt/ros/jazzy/setup.sh
 ./build.sh jazzy
+```
+
+#### For ROS2 Kilted:
+
+```shell
+source /opt/ros/kilted/setup.sh
+./build.sh kilted
 ```
 
 ### 2.4 Run Livox ROS Driver 2:

--- a/build.sh
+++ b/build.sh
@@ -4,6 +4,7 @@ readonly VERSION_ROS1="ROS1"
 readonly VERSION_ROS2="ROS2"
 readonly VERSION_HUMBLE="humble"
 readonly VERSION_JAZZY="jazzy"
+readonly VERSION_KILTED="kilted"
 
 pushd `pwd` > /dev/null
 cd `dirname $0`
@@ -21,6 +22,9 @@ elif [ "$1" = "humble" ]; then
 elif [ "$1" = "jazzy" ]; then
     ROS_VERSION=${VERSION_ROS2}
     ROS_DISTRO=${VERSION_JAZZY}
+elif [ "$1" = "kilted" ]; then
+    ROS_VERSION=${VERSION_ROS2}
+    ROS_DISTRO=${VERSION_KILTED}
 elif [ "$1" = "ROS1" ]; then
     ROS_VERSION=${VERSION_ROS1}
 else


### PR DESCRIPTION
## Summary

Adds **ROS2 Kilted** as a supported build target, alongside the existing Humble and Jazzy options.

Kilted is a standard ROS2 distro and uses the same modern `rosidl_get_typesupport_target` path as Humble/Jazzy for custom message typesupport, so support is just a matter of recognizing the distro name in the build plumbing.

## Changes

- **`build.sh`**: accept `kilted` as an argument and pass `-DDISTRO_ROS=kilted` to `colcon build`.
- **`CMakeLists.txt`**: include `kilted` in the modern-typesupport branch (`rosidl_get_typesupport_target`).
- **`README.md`**: document Kilted prerequisites, the install link, and the `./build.sh kilted` build command.

## Usage

```shell
source /opt/ros/kilted/setup.sh
./build.sh kilted
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)