### PR TITLE
Feat/in tree sdk build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 .vscode
 build
-package.xml
 __pycache__

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -259,13 +259,13 @@ else(ROS_EDITION STREQUAL "ROS2")
     LIBRARY_NAME ${PROJECT_NAME}
   )
 
-  ## make sure the livox_lidar_sdk_shared library is installed
-  find_library(LIVOX_LIDAR_SDK_LIBRARY liblivox_lidar_sdk_shared.so /usr/local/lib REQUIRED)
-
-  ##
-  find_path(LIVOX_LIDAR_SDK_INCLUDE_DIR
-    NAMES "livox_lidar_api.h" "livox_lidar_def.h"
-    REQUIRED)
+  ## Build livox_lidar_sdk_shared in-tree from the sibling Livox-SDK2 checkout
+  ## (src/thirdparty/Livox-SDK2) as part of this package's own build, instead
+  ## of requiring a prior `cmake && make install` into /usr/local.
+  set(LIVOX_SDK2_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../Livox-SDK2" CACHE PATH
+    "Path to the Livox-SDK2 source tree")
+  add_subdirectory(${LIVOX_SDK2_DIR}/sdk_core ${CMAKE_CURRENT_BINARY_DIR}/livox_sdk2)
+  set(LIVOX_LIDAR_SDK_LIBRARY livox_lidar_sdk_shared)
 
   ## PCL library
   link_directories(${PCL_LIBRARY_DIRS})
@@ -310,7 +310,6 @@ else(ROS_EDITION STREQUAL "ROS2")
   target_include_directories(${PROJECT_NAME} PUBLIC
     ${PCL_INCLUDE_DIRS}
     ${APR_INCLUDE_DIRS}
-    ${LIVOX_LIDAR_SDK_INCLUDE_DIR}
     ${LIVOX_INTERFACES_INCLUDE_DIRECTORIES}   # for custom msgs
     3rdparty
     src

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,18 @@
-# judge which cmake codes to use 
+# Default cache args so `colcon build --packages-select livox_ros_driver2`
+# works without passing -DROS_EDITION / -DDISTRO_ROS explicitly.
+if(NOT DEFINED ROS_EDITION)
+  set(ROS_EDITION "ROS2")
+endif()
+
+if(NOT DEFINED DISTRO_ROS)
+  if(DEFINED ENV{ROS_DISTRO})
+    set(DISTRO_ROS $ENV{ROS_DISTRO})
+  else()
+    set(DISTRO_ROS "jazzy")
+  endif()
+endif()
+
+# judge which cmake codes to use
 if(ROS_EDITION STREQUAL "ROS1")
 
   # Copyright(c) 2019 livoxtech limited.

--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>livox_ros_driver2</name>
+  <version>1.0.0</version>
+  <description>The ROS device driver for Livox 3D LiDARs, for ROS2</description>
+  <maintainer email="dev@livoxtech.com">feng</maintainer>
+  <license>MIT</license>
+
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
+  <build_depend>rosidl_default_generators</build_depend>
+  <member_of_group>rosidl_interface_packages</member_of_group>
+
+  <depend>rclcpp</depend>
+  <depend>rclcpp_components</depend>
+  <depend>std_msgs</depend>
+  <depend>sensor_msgs</depend>
+  <depend>rcutils</depend>
+  <depend>pcl_conversions</depend>
+  <depend>rcl_interfaces</depend>
+  <depend>libpcl-all-dev</depend>
+
+  <exec_depend>rosbag2</exec_depend>
+  <exec_depend>rosidl_default_runtime</exec_depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <depend>git</depend>
+  <depend>apr</depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>


### PR DESCRIPTION
livox_ros_driver2 previously find_library()'d liblivox_lidar_sdk_shared.so
from /usr/local/lib, which meant Livox-SDK2 had to be manually cmake/make
installed there before colcon build could succeed. In a devcontainer,
/usr/local isn't a bind mount or named volume, so that install was lost on
every rebuild (and sometimes a plain relaunch), forcing a repeated manual
build step or a postStartCommand workaround.

add_subdirectory() the sibling Livox-SDK2/sdk_core checkout directly and
link its livox_lidar_sdk_shared target instead. The SDK now builds as a
normal part of `colcon build`, and its own install(TARGETS ...) rule
installs it straight into this package's install/lib alongside the driver 
fully self-contained, no /usr/local step required.